### PR TITLE
Hide Address Web Field by default on wp-admin/options-general.php

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Changes in progress
 
 Changes 15.05.19
 ---------------------------------------------------------------------------------------
+- Hide Address Web Field by default on wp-admin/options-general.php
 - Upgraded WordPress to version 4.0.5
 - CSV: Included first version of the import-users-from-csv-with-meta plugin. #95
 - If user is not logged in, redirects at login screen on BuddyPress tabs 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,13 +5,13 @@ development home at https://github.com/projectestac/agora_nodes
 
 Changes in progress
 ---------------------------------------------------------------------------------------
-- Forbidden access to admin-tools and edit-comments for Colaborator user roles
+- Forbidden access to admin-tools and edit-comments for Collaborator user roles (Trello #790)
+- Hide Address Web Field by default on wp-admin/options-general.php (Trello #797)
 
 
 
 Changes 15.05.19
 ---------------------------------------------------------------------------------------
-- Hide Address Web Field by default on wp-admin/options-general.php
 - Upgraded WordPress to version 4.0.5
 - CSV: Included first version of the import-users-from-csv-with-meta plugin. #95
 - If user is not logged in, redirects at login screen on BuddyPress tabs 

--- a/wp-admin/options-general.php
+++ b/wp-admin/options-general.php
@@ -104,11 +104,28 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 <th scope="row"><label for="siteurl"><?php _e('WordPress Address (URL)') ?></label></th>
 <td><input name="siteurl" type="url" id="siteurl" value="<?php form_option( 'siteurl' ); ?>"<?php disabled( defined( 'WP_SITEURL' ) ); ?> class="regular-text code<?php if ( defined( 'WP_SITEURL' ) ) echo ' disabled' ?>" /></td>
 </tr>
+
+<!--
+// XTEC ************ MODIFICAT - Hide Address Web field by default
+// 2015.05.19 @nacho
+-->
+
 <tr>
 <th scope="row"><label for="home"><?php _e('Site Address (URL)') ?></label></th>
-<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php if ( defined( 'WP_HOME' ) ) echo ' disabled' ?>" />
+<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php echo ' disabled' ?>" />
 <p class="description"><?php _e('Enter the address here if you want your site homepage <a href="http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory">to be different from the directory</a> you installed WordPress.'); ?></p></td>
 </tr>
+
+<!-- //************ ORIGINAL -->
+<!--
+<tr>
+<th scope="row"><label for="home"><?php //_e('Site Address (URL)') ?></label></th>
+<td><input name="home" type="url" id="home" value="<?php //form_option( 'home' ); ?>"<?php //disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php //if ( defined( 'WP_HOME' ) ) echo ' disabled' ?>" />
+<p class="description"><?php //_e('Enter the address here if you want your site homepage <a href="http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory">to be different from the directory</a> you installed WordPress.'); ?></p></td>
+</tr>
+ -->
+<!-- //************ FI -->
+
 <tr>
 <th scope="row"><label for="admin_email"><?php _e('E-mail Address') ?> </label></th>
 <td><input name="admin_email" type="email" id="admin_email" value="<?php form_option( 'admin_email' ); ?>" class="regular-text ltr" />


### PR DESCRIPTION
Per comprovar el correcte funcionament, cal anar a wp-admin/options-general.php i comprovar que el camp "Adreça del lloc Web" està deshabilitat.