### PR TITLE
Wip hide address field

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Changes in progress
 
 Changes 15.05.19
 ---------------------------------------------------------------------------------------
+- Hide Address Web Field by default on wp-admin/options-general.php
 - Upgraded WordPress to version 4.0.5
 - CSV: Included first version of the import-users-from-csv-with-meta plugin. #95
 - If user is not logged in, redirects at login screen on BuddyPress tabs 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,6 @@ Changes in progress
 
 Changes 15.05.19
 ---------------------------------------------------------------------------------------
-- Hide Address Web Field by default on wp-admin/options-general.php
 - Upgraded WordPress to version 4.0.5
 - CSV: Included first version of the import-users-from-csv-with-meta plugin. #95
 - If user is not logged in, redirects at login screen on BuddyPress tabs 

--- a/wp-admin/options-general.php
+++ b/wp-admin/options-general.php
@@ -112,8 +112,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 
 <tr>
 <th scope="row"><label for="home"><?php _e('Site Address (URL)') ?></label></th>
-<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php echo ' disabled' ?>" />
-<p class="description"><?php _e('Enter the address here if you want your site homepage <a href="http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory">to be different from the directory</a> you installed WordPress.'); ?></p></td>
+<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>" class="regular-text code" disabled  /></td>
 </tr>
 
 <!-- //************ ORIGINAL -->

--- a/wp-admin/options-general.php
+++ b/wp-admin/options-general.php
@@ -112,7 +112,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 
 <tr>
 <th scope="row"><label for="home"><?php _e('Site Address (URL)') ?></label></th>
-<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>" class="regular-text code" disabled  /></td>
+<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>" class="regular-text code disabled" disabled="disabled"  /></td>
 </tr>
 
 <!-- //************ ORIGINAL -->

--- a/wp-admin/options-general.php
+++ b/wp-admin/options-general.php
@@ -104,11 +104,28 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 <th scope="row"><label for="siteurl"><?php _e('WordPress Address (URL)') ?></label></th>
 <td><input name="siteurl" type="url" id="siteurl" value="<?php form_option( 'siteurl' ); ?>"<?php disabled( defined( 'WP_SITEURL' ) ); ?> class="regular-text code<?php if ( defined( 'WP_SITEURL' ) ) echo ' disabled' ?>" /></td>
 </tr>
+
+<!--
+// XTEC ************ MODIFICAT - Hide Address Web field by default
+// 2015.05.19 @nacho
+-->
+
 <tr>
 <th scope="row"><label for="home"><?php _e('Site Address (URL)') ?></label></th>
-<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php if ( defined( 'WP_HOME' ) ) echo ' disabled' ?>" />
+<td><input name="home" type="url" id="home" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php echo ' disabled' ?>" />
 <p class="description"><?php _e('Enter the address here if you want your site homepage <a href="http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory">to be different from the directory</a> you installed WordPress.'); ?></p></td>
 </tr>
+
+<!-- //************ ORIGINAL -->
+<!--
+<tr>
+<th scope="row"><label for="home"><?php //_e('Site Address (URL)') ?></label></th>
+<td><input name="home" type="url" id="home" value="<?php //form_option( 'home' ); ?>"<?php //disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php //if ( defined( 'WP_HOME' ) ) echo ' disabled' ?>" />
+<p class="description"><?php //_e('Enter the address here if you want your site homepage <a href="http://codex.wordpress.org/Giving_WordPress_Its_Own_Directory">to be different from the directory</a> you installed WordPress.'); ?></p></td>
+</tr>
+ -->
+<!-- //************ FI -->
+
 <tr>
 <th scope="row"><label for="admin_email"><?php _e('E-mail Address') ?> </label></th>
 <td><input name="admin_email" type="email" id="admin_email" value="<?php form_option( 'admin_email' ); ?>" class="regular-text ltr" />


### PR DESCRIPTION
Al accedir a wp-admin/options-general.php el camp "Adreça del lloc web" no ha de poder ser editable