### PR TITLE
Restore little optimitation excerpt

### DIFF
--- a/wp-content/themes/reactor-primaria-1/post-formats/format-tac.php
+++ b/wp-content/themes/reactor-primaria-1/post-formats/format-tac.php
@@ -65,7 +65,7 @@
                        <?php reactor_do_meta_autor_date(); ?>
                    </header>
                     <div class="entry-summary">
-                    <?php (get_post_meta( get_the_ID(), '_bloc_html', true )!="on")? the_excerpt(): the_content();?>
+                    <?php ($bloc_html)? the_content() : the_excerpt(); ?>
                     </div>
               </div>
               


### PR DESCRIPTION
Per comprovar el funcionament correcte:

- Configuració de 1 article per fila
- Si esta marcada la casella de verificació de "Mostra el contingut sencer", es mostra el contingut de l'article. 
- Si no esta marcada la casella de verificació de "Mostra el contingut sencer", es mostra un resum (imatge resum + text resum i/o -si no hi ha resum- 45 paraules del contingut)