### PR TITLE
hide elements box

### DIFF
--- a/wp-content/plugins/buddypress-docs/bp-docs.php
+++ b/wp-content/plugins/buddypress-docs/bp-docs.php
@@ -313,7 +313,14 @@ class BP_Docs {
 		register_taxonomy( $this->associated_item_tax_name, array( $this->post_type_name ), array(
 			'labels'       => $associated_item_labels,
 			'hierarchical' => true,
+			// XTEC ************ MODIFICAT - Hide associate elements box (Don't show option in admin menu)
+			// 2015.07.13 @nacho
+			'show_ui'      => false,
+			//************ ORIGINAL
+			/*
 			'show_ui'      => true,
+			*/
+            //************ FI
 			'query_var'    => true,
 			'rewrite'      => array( 'slug' => 'item' ),
 		) );


### PR DESCRIPTION
Per provar el funcionament des de el Tauler, s'ha de fer clic a Budypress --> Documents. Dins de la edició d'un document, la caixa documents associats no ha de ser visible (#883)