### PR TITLE
modified xtec-admin calls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Changes in progress
 ---------------------------------------------------------------------------------------
 - Updated catalan translation for WordPress 4.2.2 (Trello #793)
 - Avoid deletion of main pages (Trello #909)
+- Modified code to check if is xtecadmin or superadmin (Trello #902)
 
 
 

--- a/wp-admin/includes/class-wp-users-list-table.php
+++ b/wp-admin/includes/class-wp-users-list-table.php
@@ -366,31 +366,26 @@ class WP_Users_List_Table extends WP_List_Table {
 
                 // XTEC ************ AFEGIT - Do not show edit link for xtecadmin (opening if)
                 // 2014.09.03 @aginard
-                global $isAgora;
-                if ($isAgora) {
-                    if (($user_object->user_login != get_xtecadmin_username()) || is_xtecadmin()) {
+				// 2015.07.31 @nacho
+                if (!is_xtec_super_admin()){
+                    if ( $user_object->user_login != get_xtecadmin_username() ) {
                         $actions['edit'] = '<a href="' . $edit_link . '">' . __( 'Edit' ) . '</a>';
                     }
                 } else {
                 //************ FI
-                    
-                $actions['edit'] = '<a href="' . $edit_link . '">' . __( 'Edit' ) . '</a>';
-                
+                	$actions['edit'] = '<a href="' . $edit_link . '">' . __( 'Edit' ) . '</a>';
                 // XTEC ************ AFEGIT - Do not show edit link for xtecadmin (closing if)
                 // 2014.09.03 @aginard
                 }
                 //************ FI
-                
 			} else {
 				$edit = "<strong>$user_object->user_login</strong><br />";
 			}
 			if ( !is_multisite() && get_current_user_id() != $user_object->ID && current_user_can( 'delete_user', $user_object->ID ) )
-
                 // XTEC ************ AFEGIT - Do not show delete link for xtecadmin (opening if)
-                // 2014.09.03 @aginard
-                {
-                global $isAgora;
-                if ($isAgora) {
+				// 2015.07.31 @nacho
+				{
+                if (!is_xtec_super_admin()){
                     if ($user_object->user_login != get_xtecadmin_username()) {
         				$actions['delete'] = "<a class='submitdelete' href='" . wp_nonce_url( "users.php?action=delete&amp;user=$user_object->ID", 'bulk-users' ) . "'>" . __( 'Delete' ) . "</a>";
                     }

--- a/wp-admin/menu.php
+++ b/wp-admin/menu.php
@@ -188,7 +188,8 @@ if ( ! is_multisite() && current_user_can( 'update_plugins' ) ) {
 
 // XTEC ************ AFEGIT - Block access to plugin management to all users but xtecadmin
 // 2014.10.21 @aginard
-if (!$isAgora || is_xtecadmin()) {
+// 2015.07.31 @nacho
+if (is_xtec_super_admin()) {
 //************ FI
 
 $menu[65] = array( sprintf( __('Plugins %s'), $count ), 'activate_plugins', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' );
@@ -250,7 +251,8 @@ $menu[80] = array( __('Settings'), 'manage_options', 'options-general.php', '', 
 	$submenu['options-general.php'][30] = array(__('Media'), 'manage_options', 'options-media.php');
 // XTEC ************ AFEGIT - Block access to permalink management to all users but xtecadmin
 // 2014.11.03 @sarjona
-if (!$isAgora || is_xtecadmin()) {
+// 2015.07.31 @nacho
+if (is_xtec_super_admin()) {
 //************ FI
 	$submenu['options-general.php'][40] = array(__('Permalinks'), 'manage_options', 'options-permalink.php');
 // XTEC ************ AFEGIT - Block access to permalink management to all users but xtecadmin

--- a/wp-admin/options-discussion.php
+++ b/wp-admin/options-discussion.php
@@ -211,8 +211,8 @@ $show_avatars = get_option( 'show_avatars' );
 <?php
 // XTEC ************ AFEGIT - hide default avatars and punctuation. It's only showed for xtecadmin.
 // 2015.02.20 @vsaavedr
-global $isAgora, $isBlocs;
-if ( ( ($isAgora) && (is_xtecadmin()) ) || ( ($isBlocs) && (is_network_admin()) ) ) {
+// 2015.07.31 @nacho
+if (is_xtec_super_admin()){
 ?>
 <tr class="avatar-settings<?php if ( ! $show_avatars ) echo ' hide-if-js'; ?>">
 <th scope="row"><?php _e('Maximum Rating'); ?></th>

--- a/wp-admin/options-permalink.php
+++ b/wp-admin/options-permalink.php
@@ -11,9 +11,9 @@ require_once( dirname( __FILE__ ) . '/admin.php' );
 
 // XTEC ************ AFEGIT - Block access to permalink management to all users but xtecadmin
 // 2014.11.03 @sarjona
-global $isAgora;
-
-if ($isAgora && !is_xtecadmin()) {
+// 2015.07.31 @sarjona
+// 2015.07.31 @nacho
+if (!is_xtec_super_admin()) {
     wp_die( __( 'You do not have sufficient permissions to manage options for this site.' ) );
 }
 //************ FI

--- a/wp-admin/options-reading.php
+++ b/wp-admin/options-reading.php
@@ -100,8 +100,9 @@ else :
 
 <!-- XTEC ************ AFEGIT - Hidden reading options. Some parameters are configured in theme. Others may confuse users -->
 <!-- 2014.09.09 @aginard: Added code is just this if. Cannot add FI tag -->
-<?php if ($isAgora && !is_xtecadmin()) { ?>
-<!--  
+<!-- 2015.07.11 @nacho -->
+<?php if (!is_xtec_super_admin()) { ?>
+<!--
 <?php } ?>
 
 <tr>
@@ -136,8 +137,9 @@ else :
 
 <!--// XTEC ************ AFEGIT - Hidden reading options. Some parameters are configured in theme. Others may confuse users -->
 <!--// 2014.09.09 @aginard
-<?php if ($isAgora && !is_xtecadmin()) { ?>
---> 
+	// 2015.07.31 @nacho
+<?php if (!is_xtec_super_admin()) { ?>
+-->
 <?php } ?>
 <!-- ************ FI -->
 
@@ -147,9 +149,11 @@ else :
 </tr>
 
 <!-- XTEC ************ AFEGIT - Hidden reading options to simplify configuration -->
-<!-- 2014.09.09 @aginard: Added code is just this if. Cannot add FI tag -->
-<?php if ($isAgora && !is_xtecadmin()) { ?>
-<!--  
+<!-- 2014.09.09 @aginard: Added code is just this if. Cannot add FI tag
+	 2015.07.11 @nacho
+-->
+<?php if (!is_xtec_super_admin()) { ?>
+<!--
 <?php } ?>
 
 <tr>
@@ -195,11 +199,12 @@ else :
 
 <!-- XTEC ************ AFEGIT - Hidden reading options to simplify configuration
 <!-- 2014.09.09 @aginard
-<?php if ($isAgora && !is_xtecadmin()) { ?>
---> 
+	 2015.07.11 @nacho
+<?php if (!is_xtec_super_admin()) { ?>
+-->
 <?php } ?>
 <!-- ************ FI -->
-    
+
 <?php do_settings_fields( 'reading', 'default' ); ?>
 </table>
 

--- a/wp-admin/plugins.php
+++ b/wp-admin/plugins.php
@@ -12,9 +12,8 @@ require_once( dirname( __FILE__ ) . '/admin.php' );
 
 // XTEC ************ AFEGIT - Block access to plugin management to all users but xtecadmin
 // 2014.10.21 @aginard
-global $isAgora;
-
-if ($isAgora && !is_xtecadmin()) {
+// 2015.07.31 @nacho
+if (!is_xtec_super_admin()) {
     wp_die( __( 'You do not have sufficient permissions to manage plugins for this site.' ) );
 }
 //************ FI

--- a/wp-admin/user-edit.php
+++ b/wp-admin/user-edit.php
@@ -176,8 +176,11 @@ $profileuser = get_user_to_edit($user_id);
 
 // XTEC ************ AFEGIT - Only xtecadmin is allowed to edit xtecadmin
 // 2014.09.03 @aginard
-if ($isAgora && ($profileuser->user_login == get_xtecadmin_username()) && !is_xtecadmin()) {
-    wp_die(__('You do not have permission to edit this user.'));
+// 2015.07.31 @nacho
+if (!is_xtec_super_admin()){
+	if ( $profileuser->user_login == get_xtecadmin_username() ) {
+		wp_die(__('You do not have permission to edit this user.'));
+	}
 }
 //************ FI
 

--- a/wp-admin/users.php
+++ b/wp-admin/users.php
@@ -167,11 +167,12 @@ case 'dodelete':
 
         // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (actual remove step)
         // 2014.09.03 @aginard
-        if ($isAgora && ($id == get_xtecadmin_id())) {
+		// 2015.07.31 @nacho
+        if (!is_xtec_super_admin()) {
             wp_die(__('You do not have permission to do that.'));
         }
         //************ FI
-        
+
         if ( ! current_user_can( 'delete_user', $id ) )
 			wp_die(__( 'You can&#8217;t delete that user.' ) );
 
@@ -242,7 +243,8 @@ case 'delete':
 
         // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (confirmation step)
         // 2014.09.03 @aginard
-        if ($isAgora && ($id == get_xtecadmin_id())) {
+		// 2015.07.31 @nacho
+        if (!is_xtec_super_admin()) {
             wp_die(__('You do not have permission to do that.'));
         }
         //************ FI


### PR DESCRIPTION
Aquesta es la llista de fitxers en les que s'han modificat les crides particulars de nodes per les de Wordpress (#902) i les proves que cal fer per tal de validar el seu funcionament:
- Class-wp-users-list-table.php: A la taula del llistat d'usuaris no apareixen els links: Suprimeix, brossa i editar en tots els casos en que l'usuari no sigui xtecadmin.
- Users.php: L'usuari xtecadmin no es pot eliminar.
- Menu.php: El link "Extensions" només es visible per l'usuari xtecadmin.
- Plugins.php: L'únic usuari que pot accedir a wp-admin/plugins.php es xtecadmin
- User-edit.php: Cap usuari pot editar la configuració de l'usuari xtecadmin, excepte ell mateix.
- Options-discussion.php: A la pestanya Paràmetres --> Discussió només l'usuari xtecadmin pot veure les opcions "Puntuació Màxima" i "Avatar Predeterminat".
- Options-permalink.php: A paràmetres --> Enllaços Permanents únicament pot accedir l'usuari xtecadmin.
- Options-reading.php: L'usuari xtecadmin disposa de més opcions a Paràmetres-->Lectura.
 