### PR TITLE
Block access to install functions

### DIFF
--- a/AFEGIT_XTEC
+++ b/AFEGIT_XTEC
@@ -1,0 +1,3 @@
+//XTEC ************ FITXERS AFEGITS
+
+siteoff.html

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Changes in progress
 - Updated catalan translation for WordPress 4.2.2 (Trello #793)
 - Avoid deletion of main pages (Trello #909)
 - Modified code to check if is xtecadmin or superadmin (Trello #902)
+- Block access to install script (Trello #521)
 
 
 

--- a/siteoff.html
+++ b/siteoff.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>			
+<html xmlns='http://www.w3.org/1999/xhtml' lang='ca'>
+    <head>
+        <meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />
+        <title>Servei no disponible</title>
+        <style type='text/css'>
+            body {		
+                margin: 0;
+                background: #eee;
+                font-family: sans-serif;
+                line-height: 1.5;
+                color: #444;
+            }
+            div {
+                width: 40em;
+                min-height: 80px;
+                padding: 1em;
+                margin: 2em auto;
+                border: 1px solid #ddd;
+                background: white;
+            }
+            p {
+                margin: 1em;
+            }
+            img {
+                float: left;
+                margin: 0 2em 0 1em;
+            }
+        </style>
+    </head>
+    <body>
+        <div>
+            <img alt="Generalitat de Catalunya - Departament d'Ensenyament" src="http://educacio.gencat.cat/img/noma/logo.gif" />
+            <br />
+            <br />
+            <p>
+                El servei a qu&egrave; intenteu accedir est&agrave; temporalment fora de servei. Estem treballant per solucionar el problema al m&eacute;s aviat possible. Si us plau proveu d'accedir-hi m&eacute;s tard.
+                <br /> 
+                <br />
+                Disculpeu les mol&egrave;sties.
+            </p>
+        </div>
+    </body>
+</html>

--- a/wp-admin/install.php
+++ b/wp-admin/install.php
@@ -155,8 +155,33 @@ function display_setup_form( $error = null ) {
 
 // Let's check to make sure WP isn't already installed.
 if ( is_blog_installed() ) {
+	//XTEC ************ MODIFICAT - Block access to install functions. Show "site off" message instead.
+	//2015.08.05 @nacho
+	if ( !isset($agora['server']['enviroment']) || ($agora['server']['enviroment'] != 'LOCAL' && $agora['server']['enviroment'] != 'DES') ) {
+		$siteoff_file = '../siteoff.html';
+		if (file_exists($siteoff_file)) {
+			include_once($siteoff_file);
+		} else {
+			echo '<html><body>';
+			echo '<div style="text-align:center; font-size:large; border-width:1px; '.
+					'    border-color:#CCC; border-style:solid; border-radius: 20px; border-collapse: collapse; '.
+					'    -moz-border-radius:20px; padding:15px; margin: 200px 100px 0px 100px;">';
+			echo '<h2>Servei no disponible</h2>';
+			echo '<p>El servei a qu&egrave; intenteu accedir est&agrave; temporalment fora de servei. Estem treballant per solucionar el problema al m&eacute;s aviat possible. Si us plau proveu d\'accedir-hi m&eacute;s tard.</p>';
+			echo '<p style="font-size:medium">Disculpeu les mol&egrave;sties.</p>';
+			echo '</div></body></html>';
+		}
+		exit(0);
+	}else {
+		display_header();
+		die( '<h1>' . __( 'Already Installed' ) . '</h1><p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p><p class="step"><a href="../wp-login.php" class="button button-large">' . __( 'Log In' ) . '</a></p></body></html>' );
+	}
+	//************ ORIGINAL
+	/*
 	display_header();
 	die( '<h1>' . __( 'Already Installed' ) . '</h1><p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p><p class="step"><a href="../wp-login.php" class="button button-large">' . __( 'Log In' ) . '</a></p></body></html>' );
+	*/
+	//************ FI
 }
 
 global $wp_version, $required_php_version, $required_mysql_version;


### PR DESCRIPTION
Bloqueja la instal·lació del Wordpress (Trello #521).
Per provar el seu funcionament, cal canviar l'entorn al fitxer de configuració (ha de ser diferent a LOCAL o DES) i accedir a https://agora/agora/usu1/wp-admin/install.php. Tot seguit ha d'aparèixer un missatge que impedeix realitzar la instal·lació.