### PR TITLE
Hidden text icon in the mobile version. Fix #229.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Changes in progress
 - Modified code to check if is xtecadmin or superadmin (Trello #902)
 - Block access to install script (Trello #521)
 - Prevent the creation of restricted pages (Trello #871)
+- Hidden text icon in the mobile version (GitHub #229)
 
 
 

--- a/wp-content/themes/reactor-primaria-1/style.css
+++ b/wp-content/themes/reactor-primaria-1/style.css
@@ -1278,6 +1278,10 @@ div.docs-info-header {
   div.gce-widget-grid table tr td {
     padding: 0.5em;
   }
+  
+  .text_icon {
+      display:none;
+  }
 }  
  
 /* Large > 1480px */


### PR DESCRIPTION
Test:
A la versió mòbil ja no es mostra el text a sota de la icona i els icones superiors (trucada, email i mapa) es mostren centrats. 

En el futur ho canviarem perquè es mostri el text a sota de la icona (#224) però de moment ho deixem com estava (ocult, no es mostra) 