### PR TITLE
Grup-classe: Second HTMLBox independent from first. Fixed #228

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Changes in progress
 - Block access to install script (Trello #521)
 - Prevent the creation of restricted pages (Trello #871)
 - Hidden text icon in the mobile version (GitHub #229)
+- Grup-Classe: Second HTML box independent of first box (GitHub #228)
 
 
 

--- a/wp-content/plugins/grup-classe/grup_classe.php
+++ b/wp-content/plugins/grup-classe/grup_classe.php
@@ -253,7 +253,7 @@ class Grup_classe_Widget extends WP_Widget {
             echo "<br>";
         }
         // Custom html/text block 
-        if (strlen(trim($text_open))>0){
+        if (strlen(trim($text_close))>0) {
             the_widget( 'WP_Widget_Text',"text=$text_close&filter=true");
         }
         echo $after_widget;


### PR DESCRIPTION
Ara, encara que el primer bloc html no tingui text, si el segon bloc html té contingut, es mostra correctament. 