### PR TITLE
Enllaços educatius: Updated edu3's url. Fix #225

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Changes in progress
 - Hidden text icon in the mobile version (GitHub #229)
 - Grup-Classe: Second HTML box independent of first box (GitHub #228)
 - Social Media: Fixed automatic links (GitHub #108)
+- Enllaços educatius: Updated URL of edu3 (GitHub #225)
 
 
 

--- a/wp-content/plugins/enllacos-educatius/enllacos-educatius.php
+++ b/wp-content/plugins/enllacos-educatius/enllacos-educatius.php
@@ -20,7 +20,7 @@ class XTEC_Widget extends WP_Widget {
         'ensenyament' => ['nom' => "Dep.Ensenyament", 'url' => 'http://www20.gencat.cat/portal/site/ensenyament', 'img' => 'ensenyament-icon.png', 'desc' => 'Pàgina del Departament d\'ensenyament'],
         'xtec' => ['nom' => "XTEC", 'url' => 'http://xtec.cat', 'img' => 'xtec-icon.png', 'desc' => 'Recursos educatius'],
         'edu365' => ['nom' => "Edu365", 'url' => 'http://edu365.cat', 'img' => 'edu365-icon.png', 'desc' => 'Recursos educatius'],
-        'edu3' => ['nom' => "Edu3", 'url' => 'http://edu3.cat', 'img' => 'edu3-icon.png', 'desc' => 'Videos educatius'],
+        'edu3' => ['nom' => "Edu3", 'url' => 'http://www.edu3.cat', 'img' => 'edu3-icon.png', 'desc' => 'Videos educatius'],
         'xarxa-docent' => ['nom' => "Xarxa Docent", 'url' => 'http://educat.xtec.cat', 'img' => 'xarxa-docent-icon.png', 'desc' => 'Xarxa de support amb més de 10.000 docents inscrits'],
         'ateneu' => ['nom' => "Ateneu", 'url' => 'http://ateneu.xtec.cat/wikiform/wikiexport/cursos/index', 'img' => 'ateneu-icon.png', 'desc' => 'Materials i recursos per la formació'],
         'alexandria' => ['nom' => "Alexandria", 'url' => 'http://alexandria.xtec.cat', 'img' => 'alexandria-icon.png', 'desc' => 'Cursos moodle i activitats PDI per descarregar'],


### PR DESCRIPTION
S'ha actualitzat la url a http://www.edu3.cat. Per alguna raó, l'adreça original http://edu3.cat ha deixat de funcionar.

Test:
Al giny Enllaços educatius, fer clic sobre la icona edu3 i veure que es carrega la página del edu3. 