### PR TITLE
Added vars custom_css from database

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,7 +20,8 @@ Changes in progress
 - BuddyPress-Group-Email-Subscription: Updated module to version 3.5.1 and revised catalan translation (Trello #793)
 - BudyyPress-Like: Updated module to version 0.2.0 and improved catalan translation (Trello #793)
 - bbPress: Updated module to version 2.5.8 (Trello #793)
-- bbPress: Fixed media upload using Fancy Editor (GitHub #130) 
+- bbPress: Fixed media upload using Fancy Editor (GitHub #130)
+- Theme reactor-primaria-1: Added fields for custom CSS (GitHub #253)
 
 
 Changes 15.08.10

--- a/wp-content/plugins/buddypress-like/includes/scripts.php
+++ b/wp-content/plugins/buddypress-like/includes/scripts.php
@@ -50,5 +50,13 @@ function bp_like_insert_head() {
     <?php
 }
 
+// XTEC ************ MODIFICAT - Revert change made by module update to fix JS code sent before <html> 
+// 2015.09.21 @aginard
+add_action( 'wp_head' , 'bp_like_insert_head' );
+//************ ORIGINAL
+/*
 add_action( 'get_header' , 'bp_like_insert_head' );
+*/
+//************ FI
+
 add_action( 'wp_print_scripts' , 'bp_like_list_scripts' );

--- a/wp-content/themes/reactor-primaria-1/style.php
+++ b/wp-content/themes/reactor-primaria-1/style.php
@@ -117,4 +117,7 @@
         }
     }
     
+    <?php echo get_option( 'common_css', '' );?>
+    <?php echo get_option( 'school_css', '' );?>
+    
 </style>


### PR DESCRIPTION
Permet afegir estils des de un camp de base de dades. Ens pot permetre arreglar temporalment (entre desplegament i desplegament) petits errors de css.

Els camps que s'han de crear a la taula **wp_options** són:
* **common_css**: s'aplica a tots els centres (pensat per fer un update massiu)
* **schools_css** : s'aplica només al centre (pensat per fer un update a un centre en concret)

Fix https://github.com/projectestac/agora_nodes/issues/253

TEST
* Crear els camps common_css i schools_css a la taula wp_options
* Afegir un estil a common_css, per exemple:  .box-title { background-color:red; } i veure com canvia la pàgina
* Afegir un estil a school_css, per exemple:  .box-title { background-color:green; } i veure com canvia la pàgina (hauria de sobreescriure el estil common)


 