### PR TITLE
Wip added nodesbox name var

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,7 @@ Changes in progress
 - BuddyPress: Updated module to version 2.3.2.1 (Trello #965)
 - AddToAny: Installed version 1.6.6 (Trello #918)
 - Added and improved translations (Trello #963)
+- Add specific variable for frontpage blog name in order to allow especial chars, like \n (Trello #972)
 
 
 

--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -68,7 +68,7 @@ function reactor_do_title_logo() {
         <div>
           <a style="font-size:<?php echo reactor_option('tamany_font_nom');?>"
              href="<?php echo home_url();?>">
-          <?php echo nl2br(get_bloginfo('name', 'display')); ?>
+          <?php echo nl2br(get_option('nodesbox_name')); ?>
           </a>
         </div>
       </div>

--- a/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
@@ -117,13 +117,13 @@ if ( !function_exists('reactor_customize_register') ) {
 		 ) );
 		 
 		 
-			$wp_customize->add_setting('blogname', array( 
-				'default'    => get_option('blogname'),
+			$wp_customize->add_setting('nodesbox_name', array( 
+				'default'    => get_option('nodesbox_name'),
 				'type'       => 'option',
 				'capability' => 'manage_options',
 				'transport'  => 'postMessage',
 			 ) );
-				$wp_customize->add_control('blogname', array( 
+				$wp_customize->add_control('nodesbox_name', array( 
 					'label'    => __('Nom del centre', 'custom_tac'),
                                         'type' => 'textarea',
 					'section'  => 'reactor_customizer_capcalera',


### PR DESCRIPTION
Actualment s'està fent servir la variable nativa blogname per mostrar el nom del centre a la caixa esquerra. Per donar la possibilitat de que el centre pugi definir la disposició del nom, es va substituir un type=text per un textarea. D'aquesta manera un centre "Escola La illa" podia canviar la disposició per defecte: 
**Escola La 
Illa**
per 
**Escola
La Illa**

El problema és que el salt de línia (\n) passa a formar part del blogname i això pot portar problemes varis. Per exemple, ja s'ha detectat que el buddypress envia el blogname a l'assumpte dels correus de suscripció i el \n fa que el mail es trenqui. 

La solució passa per independitzar la variable blogname de la composició del nom a la caixa. S'ha creat una nova varible **nodesbox_name**.

Perquè el canvi sigui transparent als usuaris, és necessari actualitzar la base de dades amb aquestes dues consultes en ordre: 

1.Crear una nova variable nodesbox_name i copiar el contingut de blogname a aquest nova variable:

> INSERT INTO wp_options (option_name, option_value) 
> SELECT 'nodesbox_name', option_value 
> from wp_options where option_name ='blogname'

2.Netejar la variable blogname de salts de línia. 

> UPDATE `wp_options` SET option_value = REPLACE(option_value, '\n', ' ') WHERE 
> option_name='blogname'

ATENCIÓ: el tercer paràmetre del REPLACE és un espai.


 