### PR TITLE
Module Add to any

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "wp-content/mu-plugins/common"]
 	path = wp-content/mu-plugins/common
 	url = https://github.com/projectestac/wordpress-mu-common.git
+[submodule "wp-content/plugins/add-to-any"]
+	path = wp-content/plugins/add-to-any
+	url = https://github.com/projectestac/wordpress-add-to-any.git

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,7 @@ Changes in progress
 - BuddyPress Activity Plus: Updated module to version 1.6.2 (Trello #793)
 - Raw HTML: Upgraded to version 1.4.15 (Trello #793)
 - BuddyPress: Updated module to version 2.3.2.1 (Trello #965)
+- AddToAny: Installed version 1.6.6 (Trello #918)
 
 
 

--- a/wp-content/mu-plugins/agora-functions.php
+++ b/wp-content/mu-plugins/agora-functions.php
@@ -363,3 +363,15 @@ add_filter('bbp_get_topic_permalink', 'bbp_get_forum_permalink_filter');
 add_filter('bbp_get_reply_permalink', 'bbp_get_forum_permalink_filter');
 add_filter('bbp_get_topic_stick_link', 'bbp_get_forum_permalink_filter');
 add_filter('bp_get_group_permalink', 'bbp_get_forum_permalink_filter');
+
+/**
+ * Disable Add_To_Any Module widgets if user is not xtecadmin
+ * @author Nacho Abejaro 
+ */
+function unregister_AddToAny_widgets() {
+	if (!is_xtec_super_admin()) {
+		unregister_widget( 'A2A_SHARE_SAVE_Widget' );
+		unregister_widget( 'A2A_Follow_Widget' );
+	}
+}
+add_action('widgets_init', 'unregister_AddToAny_widgets');


### PR DESCRIPTION
Ja es pot incorporar el submòdul AddToAny, la branca WIP-Add-to-any incorpora canvis al fitxer agora-functions.php que eviten que apareguin els widgets del mòdul. Per provar aquest mòdul, només cal crear un article i comprovar que apareixen els botons per compartir. L'usuari xtecadmin ha de veure mes opcions de configuració que l'usuari admin, però les opcions "Emplaçament" no s'han de poder canviar mai (per defecte han de estar activades: Display at the xxx of the post, Display at the xxx of posts on archive pages i Display at the xxx of pages)