### PR TITLE
WIP-Delete-User-Account

### DIFF
--- a/wp-admin/users.php
+++ b/wp-admin/users.php
@@ -137,7 +137,7 @@ case 'promote':
 	wp_redirect(add_query_arg('update', $update, $redirect));
 	exit();
 
-case 'dodelete':
+case 'dodelete':	
 	if ( is_multisite() )
 		wp_die( __('User deletion is not allowed from this screen.') );
 
@@ -164,14 +164,6 @@ case 'dodelete':
 	$delete_count = 0;
 
 	foreach ( $userids as $id ) {
-
-        // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (actual remove step)
-        // 2014.09.03 @aginard
-		// 2015.07.31 @nacho
-        if (!is_xtec_super_admin()) {
-            wp_die(__('You do not have permission to do that.'));
-        }
-        //************ FI
 
         if ( ! current_user_can( 'delete_user', $id ) )
 			wp_die(__( 'You can&#8217;t delete that user.' ) );
@@ -237,21 +229,24 @@ case 'delete':
 <?php endif; ?>
 
 <ul>
-<?php
+<?php	
 	$go_delete = 0;
-	foreach ( $userids as $id ) {
-
-        // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (confirmation step)
-        // 2014.09.03 @aginard
-		// 2015.07.31 @nacho
-        if (!is_xtec_super_admin()) {
-            wp_die(__('You do not have permission to do that.'));
-        }
-        //************ FI
-
+	foreach ( $userids as $id ) {        
 		$user = get_userdata( $id );
+		$username = $user->user_login;		
+		// XTEC ************ MODIFICAT - Xtecadmin and admin user cannot be deleted (confirmation step)
+		// 2015.11.05 @nacho
+		if ( $id == $current_user->ID || ( $username == 'admin' || $username == 'xtecadmin' ) ) {
+		//************ ORIGINAL
+		/*
 		if ( $id == $current_user->ID ) {
+		*/
+		//************ FI
 			echo "<li>" . sprintf(__('ID #%1$s: %2$s <strong>The current user will not be deleted.</strong>'), $id, $user->user_login) . "</li>\n";
+			// XTEC ************ AFEGIT - Xtecadmin and admin user cannot be deleted (confirmation step)
+			// 2015.11.05 @nacho
+			exit;
+			//************ FI
 		} else {
 			echo "<li><input type=\"hidden\" name=\"users[]\" value=\"" . esc_attr($id) . "\" />" . sprintf(__('ID #%1$s: %2$s'), $id, $user->user_login) . "</li>\n";
 			$go_delete++;


### PR DESCRIPTION
Permet als usuaris administradors eliminar comptes d'usuaris (excepte: admin, xtecadmin i eliminar-se ell mateix) (Trello #991)