### PR TITLE
WIP-Header-links

### DIFF
--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -133,9 +133,6 @@ function reactor_do_title_logo() {
                 <a title="Trucar" href="tel:<?php echo reactor_option('telCentre'); ?>" class="dashicons dashicons-phone"></a>
                 <span class="text_icon"><?php echo reactor_option('telCentre'); ?></span>   
             </div>
-<!--  XTEC ************ MODIFICAT - Check if the path is absolute or relative to mount the header link
-// 2015.11.09 @nacho
--->
 			<div id="icon-11">
             	<?php
             	$url = parse_url($options['link_icon11']);
@@ -243,51 +240,6 @@ function reactor_do_title_logo() {
             	}
             	?>
             </div>
-<!-- //************ ORIGINAL
-			<div id="icon-11">
-                <a title="<?php //echo $options['title_icon11'];?>" 
-                   href="<?php //echo $options['link_icon11'];?>" 
-                   class="dashicons dashicons-<?php //echo $options['icon11'];?>"
-                   <?php //echo set_target($options['link_icon11']);?>>
-                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon11']);?>" class="text_icon"><?php //echo $options['title_icon11'];?> </span>
-                </a>
-            </div>
-            <div id="icon-12">
-                <a class="dashicons dashicons-<?php //echo $options['icon12'];?>" 
-                   title="<?php //echo $options['title_icon12'];?>" 
-                   href="<?php //echo $options['link_icon12'];?>" 
-                   <?php //echo set_target($options['link_icon12']);?>>
-                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon12']);?>" class="text_icon"><?php //echo $options['title_icon12'];?> </span>
-                </a>
-            </div>
-            <div id="icon-13">
-                <a class="dashicons dashicons-search" title="CERCA" href="javascript:void(0);" onclick='cerca_toggle();'>
-                    <span class="text_icon">cerca</span>   
-                </a>
-            </div>
-            <div id="search-panel">
-                <form role="search" method="get" class="search-form" action="<?php //echo get_home_url();?>">
-                    <input type="search" class="search-field" placeholder="Cerca i pulsa enter…" value="" name="s" title="Cerca:">
-                    <input type="submit" style="position: absolute; left: -9999px; width: 1px; height: 1px;">
-                </form>			
-            </div>
-            <div id="icon-21">
-                 <a class="dashicons dashicons-<?php //echo $options['icon21'];?>" 
-                    title="<?php //echo $options['title_icon21'];?>" 
-                    href="<?php //echo $options['link_icon21'];?>" 
-                    <?php //echo set_target($options['link_icon21']);?>>
-                    <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon21']);?>" class="text_icon"><?php //echo $options['title_icon21'];?> </span>
-                 </a>
-            </div>
-            <div id="icon-22">
-                <a class="dashicons dashicons-<?php //echo $options['icon22'];?>" 
-                   title="<?php //echo $options['title_icon22'];?>" 
-                   href="<?php //echo $options['link_icon22'];?>" 
-                   <?php //echo set_target($options['link_icon22']);?>>
-                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon22']);?>" class="text_icon"><?php //echo $options['title_icon22'];?> </span>
-                </a>
-            </div>
-//************ FI -->            
             <div id="icon-23">
                 <a class="dashicons dashicons-menu" 
                    title="MENU" 

--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -133,21 +133,56 @@ function reactor_do_title_logo() {
                 <a title="Trucar" href="tel:<?php echo reactor_option('telCentre'); ?>" class="dashicons dashicons-phone"></a>
                 <span class="text_icon"><?php echo reactor_option('telCentre'); ?></span>   
             </div>
-            <div id="icon-11">
-                <a title="<?php echo $options['title_icon11'];?>" 
-                   href="<?php echo $options['link_icon11'];?>" 
+<!--  XTEC ************ MODIFICAT - Check if the path is absolute or relative to mount the header link
+// 2015.11.09 @nacho
+-->
+			<div id="icon-11">
+            	<?php
+            	$url = parse_url($options['link_icon11']);
+            	if ( ($url['scheme'] == 'https') || ($url['scheme'] == 'http') ){
+            	?>
+            	<a title="<?php echo $options['title_icon11'];?>"
+                   href="<?php echo $options['link_icon11'];?>"
                    class="dashicons dashicons-<?php echo $options['icon11'];?>"
                    <?php echo set_target($options['link_icon11']);?>>
                    <span style="font-size:<?php echo get_icon_font_size( $options['title_icon11']);?>" class="text_icon"><?php echo $options['title_icon11'];?> </span>
                 </a>
+                <?php
+            	}else {
+            		$link_url = get_home_url()."/".$options['link_icon11'];
+            	?>
+            	<a title="<?php echo $options['title_icon11'];?>"
+                   href="<?php echo $link_url;?>"
+                   class="dashicons dashicons-<?php echo $options['icon11'];?>">
+                   <span style="font-size:<?php echo get_icon_font_size( $options['title_icon11']);?>" class="text_icon"><?php echo $options['title_icon11'];?> </span>
+                </a>
+            	<?php
+            	}
+            	?>
             </div>
             <div id="icon-12">
-                <a class="dashicons dashicons-<?php echo $options['icon12'];?>" 
-                   title="<?php echo $options['title_icon12'];?>" 
-                   href="<?php echo $options['link_icon12'];?>" 
+            	<?php
+            	$url = parse_url($options['link_icon12']);
+            	if ( ($url['scheme'] == 'https') || ($url['scheme'] == 'http') ){
+            	?>
+            	<a title="<?php echo $options['title_icon12'];?>"
+                   href="<?php echo $options['link_icon12'];?>"
+                   class="dashicons dashicons-<?php echo $options['icon12'];?>"
                    <?php echo set_target($options['link_icon12']);?>>
                    <span style="font-size:<?php echo get_icon_font_size( $options['title_icon12']);?>" class="text_icon"><?php echo $options['title_icon12'];?> </span>
                 </a>
+                <?php
+            	}else {
+            		$link_url = get_home_url()."/".$options['link_icon12'];
+            	?>
+            	<a title="<?php echo $options['title_icon12'];?>"
+                   href="<?php echo $link_url;?>"
+                   class="dashicons dashicons-<?php echo $options['icon12'];?>">
+                   <span style="font-size:<?php echo get_icon_font_size( $options['title_icon12']);?>" class="text_icon"><?php echo $options['title_icon12'];?> </span>
+                </a>
+            	<?php
+            	}
+            	?>
             </div>
             <div id="icon-13">
                 <a class="dashicons dashicons-search" title="CERCA" href="javascript:void(0);" onclick='cerca_toggle();'>
@@ -161,21 +196,98 @@ function reactor_do_title_logo() {
                 </form>			
             </div>
             <div id="icon-21">
-                 <a class="dashicons dashicons-<?php echo $options['icon21'];?>" 
-                    title="<?php echo $options['title_icon21'];?>" 
-                    href="<?php echo $options['link_icon21'];?>" 
-                    <?php echo set_target($options['link_icon21']);?>>
-                    <span style="font-size:<?php echo get_icon_font_size( $options['title_icon21']);?>" class="text_icon"><?php echo $options['title_icon21'];?> </span>
-                 </a>
+                 <?php
+            	$url = parse_url($options['link_icon21']);
+            	if ( ($url['scheme'] == 'https') || ($url['scheme'] == 'http') ){
+            	?>
+            	<a class="dashicons dashicons-<?php echo $options['icon21'];?>"
+                   title="<?php echo $options['title_icon21'];?>"
+                   href="<?php echo $options['link_icon21'];?>"
+                   <?php echo set_target($options['link_icon21']);?>>
+                   <span style="font-size:<?php echo get_icon_font_size( $options['title_icon21']);?>" class="text_icon"><?php echo $options['title_icon21'];?> </span>
+                </a>
+                <?php
+            	}else {
+            		$link_url = get_home_url()."/".$options['link_icon21'];
+            	?>
+            	<a title="<?php echo $options['title_icon21'];?>"
+                   href="<?php echo $link_url;?>"
+                   class="dashicons dashicons-<?php echo $options['icon21'];?>">
+                   <span style="font-size:<?php echo get_icon_font_size( $options['title_icon21']);?>" class="text_icon"><?php echo $options['title_icon21'];?> </span>
+                </a>
+            	<?php
+            	}
+            	?>
             </div>
             <div id="icon-22">
-                <a class="dashicons dashicons-<?php echo $options['icon22'];?>" 
-                   title="<?php echo $options['title_icon22'];?>" 
-                   href="<?php echo $options['link_icon22'];?>" 
+	    	<?php
+            	$url = parse_url($options['link_icon22']);
+            	if ( ($url['scheme'] == 'https') || ($url['scheme'] == 'http') ){
+            	?>
+            	<a class="dashicons dashicons-<?php echo $options['icon22'];?>"
+                   title="<?php echo $options['title_icon22'];?>"
+                   href="<?php echo $options['link_icon22'];?>"
                    <?php echo set_target($options['link_icon22']);?>>
                    <span style="font-size:<?php echo get_icon_font_size( $options['title_icon22']);?>" class="text_icon"><?php echo $options['title_icon22'];?> </span>
                 </a>
+                <?php
+            	}else {
+            		$link_url = get_home_url()."/".$options['link_icon22'];
+            	?>
+            	<a title="<?php echo $options['title_icon22'];?>"
+                   href="<?php echo $link_url;?>"
+                   class="dashicons dashicons-<?php echo $options['icon22'];?>">
+                   <span style="font-size:<?php echo get_icon_font_size( $options['title_icon22']);?>" class="text_icon"><?php echo $options['title_icon22'];?> </span>
+                </a>
+            	<?php
+            	}
+            	?>
             </div>
+<!-- //************ ORIGINAL
+			<div id="icon-11">
+                <a title="<?php //echo $options['title_icon11'];?>" 
+                   href="<?php //echo $options['link_icon11'];?>" 
+                   class="dashicons dashicons-<?php //echo $options['icon11'];?>"
+                   <?php //echo set_target($options['link_icon11']);?>>
+                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon11']);?>" class="text_icon"><?php //echo $options['title_icon11'];?> </span>
+                </a>
+            </div>
+            <div id="icon-12">
+                <a class="dashicons dashicons-<?php //echo $options['icon12'];?>" 
+                   title="<?php //echo $options['title_icon12'];?>" 
+                   href="<?php //echo $options['link_icon12'];?>" 
+                   <?php //echo set_target($options['link_icon12']);?>>
+                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon12']);?>" class="text_icon"><?php //echo $options['title_icon12'];?> </span>
+                </a>
+            </div>
+            <div id="icon-13">
+                <a class="dashicons dashicons-search" title="CERCA" href="javascript:void(0);" onclick='cerca_toggle();'>
+                    <span class="text_icon">cerca</span>   
+                </a>
+            </div>
+            <div id="search-panel">
+                <form role="search" method="get" class="search-form" action="<?php //echo get_home_url();?>">
+                    <input type="search" class="search-field" placeholder="Cerca i pulsa enter…" value="" name="s" title="Cerca:">
+                    <input type="submit" style="position: absolute; left: -9999px; width: 1px; height: 1px;">
+                </form>			
+            </div>
+            <div id="icon-21">
+                 <a class="dashicons dashicons-<?php //echo $options['icon21'];?>" 
+                    title="<?php //echo $options['title_icon21'];?>" 
+                    href="<?php //echo $options['link_icon21'];?>" 
+                    <?php //echo set_target($options['link_icon21']);?>>
+                    <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon21']);?>" class="text_icon"><?php //echo $options['title_icon21'];?> </span>
+                 </a>
+            </div>
+            <div id="icon-22">
+                <a class="dashicons dashicons-<?php //echo $options['icon22'];?>" 
+                   title="<?php //echo $options['title_icon22'];?>" 
+                   href="<?php //echo $options['link_icon22'];?>" 
+                   <?php //echo set_target($options['link_icon22']);?>>
+                   <span style="font-size:<?php //echo get_icon_font_size( $options['title_icon22']);?>" class="text_icon"><?php //echo $options['title_icon22'];?> </span>
+                </a>
+            </div>
+//************ FI -->            
             <div id="icon-23">
                 <a class="dashicons dashicons-menu" 
                    title="MENU" 


### PR DESCRIPTION
(Trello #1008)
El funcionament dels icones de la capçalera no estava preparat per funcionar amb links relatius.
Per provar les modificacions cal anar al menú d'Administració --> Aparença --> Icones de capçalera i canviar els enllaços absoluts per relatius. Exemple: Modificar el link de Nodes per (activitat) i guardar els canvis. El link de nodes del header ha de funcionar correctament i mostrar el menú Nodes a la mateixa pàgina. Si es torna a possar una URL absoluta ha de seguir funcionant. 

@toniginard  NOTAL: L'única diferencia es que els links absoluts obren el contingut en una pestanya nova (codi original), en canvi he fer que els relatius mostrin el contingut a la mateixa pestanya. Si es necessari canviar-ho diga'm-ho.