### PR TITLE
WIP-Delete-User-Account

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Changes in progress
 - wp-recaptcha: Added default configuration for Nodes when activating plugin (Trello #926) 
 - Added ability to decide if a client is "Servei Educatiu" (Trello #981)
 - Added theme reactor-serveis-educatius (Trello #981)
+- Fixed admin users not being able to delete users (Trello #991)
 
 
 Changes 15.10.09

--- a/wp-admin/users.php
+++ b/wp-admin/users.php
@@ -165,14 +165,6 @@ case 'dodelete':
 
 	foreach ( $userids as $id ) {
 
-        // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (actual remove step)
-        // 2014.09.03 @aginard
-		// 2015.07.31 @nacho
-        if (!is_xtec_super_admin()) {
-            wp_die(__('You do not have permission to do that.'));
-        }
-        //************ FI
-
         if ( ! current_user_can( 'delete_user', $id ) )
 			wp_die(__( 'You can&#8217;t delete that user.' ) );
 
@@ -240,18 +232,27 @@ case 'delete':
 <?php
 	$go_delete = 0;
 	foreach ( $userids as $id ) {
+		$user = get_userdata( $id );
 
-        // XTEC ************ AFEGIT - Xtecadmin cannot be deleted (confirmation step)
-        // 2014.09.03 @aginard
-		// 2015.07.31 @nacho
-        if (!is_xtec_super_admin()) {
-            wp_die(__('You do not have permission to do that.'));
-        }
+        // XTEC ************ MODIFICAT - Xtecadmin and admin users cannot be deleted (confirmation step)
+        // 2015.11.05 @nacho
+
+        $username = $user->user_login;
+		if ( $id == $current_user->ID || $username == ADMIN_USERNAME || $username == XTECADMIN_USERNAME ) {
+
+        //************ ORIGINAL
+        /*
+        if ( $id == $current_user->ID ) {
+        */
         //************ FI
 
-		$user = get_userdata( $id );
-		if ( $id == $current_user->ID ) {
-			echo "<li>" . sprintf(__('ID #%1$s: %2$s <strong>The current user will not be deleted.</strong>'), $id, $user->user_login) . "</li>\n";
+                echo "<li>" . sprintf(__('ID #%1$s: %2$s <strong>The current user will not be deleted.</strong>'), $id, $user->user_login) . "</li>\n";
+
+            // XTEC ************ AFEGIT - Xtecadmin and admin user cannot be deleted (confirmation step)
+            // 2015.11.05 @nacho
+			exit;
+            //************ FI
+
 		} else {
 			echo "<li><input type=\"hidden\" name=\"users[]\" value=\"" . esc_attr($id) . "\" />" . sprintf(__('ID #%1$s: %2$s'), $id, $user->user_login) . "</li>\n";
 			$go_delete++;


### PR DESCRIPTION
Permet als usuaris administradors eliminar comptes d'usuaris (excepte: admin, xtecadmin i eliminar-se ell mateix) (Trello #991)