### PR TITLE
WIP-Menu-container

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Changes in progress
 - XTEC lib: Changed replace_url to support only a single URL (Trello #1027)
 - Theme reactor-serveis-educatius: Improved menu and added search option in responsive version (Trello #981)
 - Theme reactor: Fixed position of the legends of the images in custom galleries inserted in articles (Trello #1011)
+- Theme reactor-primaria-1: Fixed side menu in pages when there are subpages. (Trello #1010)
 
 
 

--- a/wp-content/themes/reactor-primaria-1/style.css
+++ b/wp-content/themes/reactor-primaria-1/style.css
@@ -935,35 +935,6 @@ ul.bbp-topics, .bbp-topic-form {
   clear: inherit !important;
 }
 
-body.buddypress .addtoany_share_save_container { 
-    display:none; 
-}
-
-.bbp-reply-content p, .bbp-topic-title {
-  font-size: 1.5em !important; 
-}
-
-#buddypress h3{
-    font-size:1em;
-}
-
-#wp-bbp_reply_content-editor-container,
-#wp-bbp_reply_content-editor-container{
-    border:1px solid #ddd !important;
-}
-
-.forums.bbp-replies{
-    border:1px solid #ddd !important;
-}
-
-#bbp_topic_tags,
-[for=bbp_topic_tags]{
-    display:none !important;
-}
-#bbpress-forums fieldset.bbp-form {
-  border: 1px solid #ddd !important;
-}
-    
 /* Calendari */
 
 .gce-widget-grid .gce-calendar td {
@@ -1351,11 +1322,6 @@ body.login .wp-social-login-widget{
   .text_icon {
       display:none;
   }
-  
-  body.single #sidebar { 
-      display:none; 
-  }
-  
 }  
  
 /* Large > 1480px */
@@ -1363,26 +1329,121 @@ body.login .wp-social-login-widget{
   html{
     background-color:#E2E2E2;  
    
-    }
-    
-    body {
-      width: 1480px;
-      margin-left: auto;
-      margin-right: auto;
-      border-left:3px solid #ddd;
-      border-right:3px solid #ddd;
-    }
-    
-    .box-content a, 
-    .box-content span{
-      font-size: 30px !important;      
-    }
-    
+  }
+  body {
+    width: 1480px;
+    margin-left: auto;
+    margin-right: auto;
+    border-left:3px solid #ddd;
+    border-right:3px solid #ddd;
+  }
+  .box-content a,
+  .box-content span{
+    font-size: 30px !important;
+  }
         
-    .box-content-grid a:before{
-      font-size: 2em !important;   
-    }
-    .box-content-grid a,.box-content-grid span {
-      font-size: 1em !important;
-    }
+  .box-content-grid a:before{
+    font-size: 2em !important;
+  }
+  .box-content-grid a,.box-content-grid span {
+    font-size: 1em !important;
+  }
 }
+
+/**
+ * 2015.11.13 @nacho: Customize the customSection, noChildren and dropDown classes when Side_Menu_walker is loaded
+*/
+.section-container.accordion > .customSection div.content {
+    padding: 0 0.9375em;
+    background-color: #FFF;
+    border: 1px solid #CCC;
+}
+
+.section-container.accordion > .customSection > .title a {
+    padding: 0.9375em;
+    color: #333;
+    font-size: 0.875em;
+    background: transparent none repeat scroll 0% 0%;
+    display: inline-block;    
+}
+
+.section-container.accordion > .customSection p {
+    font-family: inherit;
+    font-weight: normal;
+    font-size: 1em;
+    line-height: 1.6;
+    margin-bottom: 0em;
+    text-rendering: optimizelegibility;
+    background: #D5D5D5 none repeat scroll 0% 0%;
+    border-color: #CCC;
+    border-style: solid;
+    border-width: 0px 0px 1px;
+}
+
+.section-container.accordion > .section > .title a,
+.section-container.accordion > .customSection > .title a {
+    padding-right: 30px;
+    white-space: normal;
+}
+
+.section-container.accordion > .customSection ul {
+    padding-top: 0px;    
+    display: block;
+    margin: 0px;
+    padding: 0.875em 0px;
+    list-style-type: none;
+    list-style-position: inside;
+    font-size: 1em;
+    line-height: 1.6;    
+    list-style-position: outside;
+    font-family: inherit;
+}
+
+.section-container.accordion > .customSection li {
+    padding-left: 2em;
+    margin: 0px 0px 0.4375em;
+    font-size: 0.875em;
+}
+
+.section-container.accordion > .customSection {
+    position: relative;
+}
+
+.dashicons, .dashicons-before:before {
+    content: "\f347";
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+    line-height: 1;
+    font-family: dashicons;
+    text-decoration: inherit;
+    font-weight: 400;
+    font-style: normal;
+    vertical-align: top;
+    text-align: center;
+}
+
+.customSection .dashicons-arrow-down-alt2:before {
+    content: "\f343" !important;
+}
+
+.dropDown {
+	position: absolute;
+	right: 20px;
+	top: 15px;
+}
+
+#side-menu .section, #side-menu .customSection.active {
+	position: relative !important;
+}
+
+.noChildren .dashicons, .noChildren .dashicons-before:before {
+	content: "";
+}
+
+.noChildren .dashicons-arrow-down-alt2:before {
+	content: "";
+}
+/**
+ *End @nacho
+*/

--- a/wp-content/themes/reactor-primaria-1/style.php
+++ b/wp-content/themes/reactor-primaria-1/style.php
@@ -15,7 +15,7 @@
    
     ?>
     .box-title{
-       background-color:<?php echo $color_primary;?>
+        background-color:<?php echo $color_primary;?>
     }
     .box-description{
         background-color:<?php echo $color_secondary; ?>
@@ -29,7 +29,8 @@
     #icon-22 a {
         color:<?php echo $color_icon22;?> !important;
     }
-    h1, h2, h3, h4, h5, h6, a {    
+    /** 2015.11.13 @nacho: Display correct color for arrows on SideMenuWalker Menu**/
+    h1, h2, h3, h4, h5, h6, a, .dropDown.dashicons {
         color: <?php echo $color_link;?>  !important;
     }
     #menu-panel {

--- a/wp-content/themes/reactor/library/inc/extensions/menus.php
+++ b/wp-content/themes/reactor/library/inc/extensions/menus.php
@@ -143,7 +143,7 @@ if ( !function_exists('reactor_footer_links') ) {
  * @credit wearerequired http://required.ch/
  * @since 1.2.0
  */
-if ( !function_exists('reactor_side_menu') ) { 
+if ( !function_exists('reactor_side_menu') ) {
 	function reactor_side_menu( $nav_args = '' ) {
 		global $post;
 		
@@ -196,9 +196,7 @@ if ( !function_exists('reactor_side_menu') ) {
 		
 		// display the menu if there are subpages
 		if ( $children ) {
-			
 			$output = $nav_args['before'] . $children . $nav_args['after'];
-
 			echo $output;
 		}
 	}

--- a/wp-content/themes/reactor/library/inc/extensions/walkers.php
+++ b/wp-content/themes/reactor/library/inc/extensions/walkers.php
@@ -329,36 +329,45 @@ class Side_Menu_Walker extends Walker_Page {
 
     function start_el( &$output, $page, $depth = 0, $args = array(), $current_page = 0 ) {
 
-        extract( $args, EXTR_SKIP );
-        $classes = array( 'page_item', 'page-item-' . $page->ID );
-		
-            if ( !empty( $current_page ) ) {
-                $_current_page = get_page( $current_page );
-			}
-			
-            if ( isset( $_current_page->ancestors ) && in_array( $page->ID, ( array ) $_current_page->ancestors ) ) {
-                $classes[] = 'current_page_ancestor';
-			}
-			
-            if ( $page->ID == $current_page ) {
-                $classes[] = 'current_page_item active';
-			} elseif ( $_current_page && $page->ID == $_current_page->post_parent ) {
-                $classes[] = 'current_page_parent';
-            } elseif ( $page->ID == get_option('page_for_posts') ) {
-                $classes[] = 'current_page_parent';
-            }
+		extract( $args, EXTR_SKIP );
+		$classes = array( 'page_item', 'page-item-' . $page->ID );
+
+		if ( !empty( $current_page ) ) {
+			$_current_page = get_page( $current_page );
+		}
+		if ( isset( $_current_page->ancestors ) && in_array( $page->ID, ( array ) $_current_page->ancestors ) ) {
+			$classes[] = 'current_page_ancestor';
+		}
+		if ( $page->ID == $current_page ) {
+			$classes[] = 'current_page_item active';
+		} elseif ( $_current_page && $page->ID == $_current_page->post_parent ) {
+			$classes[] = 'current_page_parent';
+        } elseif ( $page->ID == get_option('page_for_posts') ) {
+			$classes[] = 'current_page_parent';
+		}
 
 		// create sections
+		// XTEC ************ MODIFICAT - Added class customSection for sections with childrens
+		// 2015.11.13 @nacho
+		$section_class = ( $depth == 0 && in_array('current_page_ancestor', $classes) ) ? 'customSection' : 'section';
+		//************ ORIGINAL
+		/*
 		$section_class = ( $depth == 0 && in_array('current_page_ancestor', $classes) ) ? 'section active' : 'section';
-		
+		*/
+		//************ FI
 		$classes = implode(' ', apply_filters('page_css_class', $classes, $page ) );
-		
-		$output .= ( $depth == 0 ) ? '<div class="' . $section_class . '">' : '';			
-		
-        $output .= ( $depth == 0 ) ? '<p class="' . $classes . ' title" data-section-title>' : '<li class="' . $classes . '">';
-        $output .= '<a href="' . get_page_link( $page->ID ) . '" title="' . esc_attr( wp_strip_all_tags( $page->post_title ) ) . '">';
-        $output .= $args['link_before'] . $page->post_title . $args['link_after'];
-        $output .= '</a>';
+		// XTEC ************ MODIFICAT - Added class dropDrown for display arrows
+		// 2015.11.13 @nacho
+		$output .= ( $depth == 0 ) ? '<div class="' . $section_class . '"><span class="dropDown dashicons dashicons-arrow-down-alt2"></span>' : '';
+		//************ ORIGINAL
+		/*
+		$output .= ( $depth == 0 ) ? '<div class="' . $section_class . '">' : '';
+		*/
+		//************ FI
+		$output .= ( $depth == 0 ) ? '<p class="' . $classes . ' title" data-section-title>' : '<li class="' . $classes . '">';
+		$output .= '<a href="' . get_page_link( $page->ID ) . '" title="' . esc_attr( wp_strip_all_tags( $page->post_title ) ) . '">';
+		$output .= $args['link_before'] . $page->post_title . $args['link_after'];
+		$output .= '</a>';
 		$output .= ( $depth == 0 && empty( $args['has_children'] ) ) ? '</div>' : '';
     }
 	
@@ -367,5 +376,4 @@ class Side_Menu_Walker extends Walker_Page {
 			$output .= "</li>";
 		}
     }
-
 }

--- a/wp-content/themes/reactor/library/js/reactor.js
+++ b/wp-content/themes/reactor/library/js/reactor.js
@@ -1,34 +1,79 @@
 /* Reactor - Anthony Wilhelm - http://awtheme.com/ */
 ( function($) {
+	$(document).ready( function() {
+		/* adds .button class to submit button on comment form */
+		$('#commentform input#submit').addClass('button').addClass('small');
 
-  $(document).ready( function() {
-	
-    /* adds .button class to submit button on comment form */
-    $('#commentform input#submit').addClass('button').addClass('small');
-  
-    /* adjust site for fixed top-bar with wp admin bar */
-    if($('body').hasClass('admin-bar')) {
-    	if($('.top-bar').parent().hasClass('fixed')) {
-    		
-		if($('body').hasClass('has-top-bar')) {
-	    	    $('.top-bar').parent().css('margin-top', "+=28");
+		/* adjust site for fixed top-bar with wp admin bar */
+		if($('body').hasClass('admin-bar')) {
+			if($('.top-bar').parent().hasClass('fixed')) {
+				if($('body').hasClass('has-top-bar')) {
+					$('.top-bar').parent().css('margin-top', "+=28");
+				}
+				$('body').css('padding-top', "+=28");
+			}
 		}
-		
-		$('body').css('padding-top', "+=28");
-	}
+
+	/* prevent default if menu links are # */
+	$('nav a').each(function() {
+		var nav = $(this);
+		if(nav.attr('href') == '#') {
+			$(this).on('click', function(e){
+				e.preventDefault();
+			});
+		}
+	});
+
+	/**
+	* // XTEC ************ AFEGIT
+	* SideMenuWalker: Search all div class="section" when document is ready,
+    * and check if the section have not childrens (div="content"). If not found any children,
+    * class "noChildren" is added for no load the up arrow image
+	* 2015.11.13 @nacho
+    */
+	var SideMenuWalker = {
+		init: function() {
+			var sections = $('div.section');
+			var content = sections.find('div.content');
+			sections.each(function(index, value){
+				var self = jQuery(this);
+				var content = self.find('div.content');
+				if (!content.length) {
+					self.addClass("noChildren");
+				}
+			});
+		}
     }
+	SideMenuWalker.init();
 
-    /* prevent default if menu links are # */
-    $('nav a').each(function() {
-        var nav = $(this); 
-        if(nav.attr('href') == '#') {
-            $(this).on('click', function(e){ 
-                e.preventDefault();
-            });
-        }
-    });
+	/**
+     * Control the click event on dropDown class to add or remove a parent class
+    */
+	$('.dropDown').on('click', function(e) {
+		e.preventDefault();
+		var section = $(this).parent().closest('div');
 
-    /* MixItUp - http://mixitup.io/ */
+		if (section.hasClass('section')){
+			section.removeClass("section");
+			section.addClass("customSection active");
+		}else {
+			section.removeClass("customSection active");
+			section.addClass("section");
+		}
+	});
+
+	/**
+     * Control the click event on a section for load the content through the correct link
+     */
+	$('.section a').on('click', function(e) {
+		e.preventDefault();
+		e.stopPropagation();
+		var href = $(this);
+		window.location.href = href.attr('href');
+	});
+	//************ FI
+
+	/* MixItUp - http://mixitup.io/ */
     if($().mixitup) {
         $(function(){
             $('#Grid').mixitup();
@@ -49,5 +94,4 @@
 	
 	/* Initialize Foundation Scripts */
 	$(document).foundation();
-
-})( jQuery );	
+})( jQuery );


### PR DESCRIPTION
S'ha modificat el menú acordió per mostrar correctament les pàgines i les subpàgines(Trello #1010)
Per provar els canvis cal crear una pàgina que sigui filla d'una altre i cal seleccionar com a plantilla "barra esquerra subpàgines. Quan visualitzem el contingut, el menú acordió permet visualitzant el contingut, tant de la pàgina mare com el de la filla.