### PR TITLE
WIP-Legal-warning

### DIFF
--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-footer.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-footer.php
@@ -60,7 +60,7 @@ function reactor_do_footer_content() { ?>
         <div class="row">
             <div class="<?php reactor_columns( 12 ); ?>">
                 <div style="text-align:center" id="colophon">
-                    <p> <a target="_blank" href="http://www.xtec.cat/web/guest/avis">Avís legal</a> |
+                    <p> <a target="_blank" href="http://xtec.gencat.cat/ca/condicions-us">Avís legal</a> |
                     <a target="_blank" href="http://agora.xtec.cat/nodes/">Sobre el web</a> |
                     <span class="copyright">&copy;<?php echo date_i18n('Y'); ?>  Generalitat de Catalunya | </span>
                     <span class="site-source">Fet amb <a href=http://wordpress.org/>WordPress</a></span></p>

--- a/wp-content/themes/reactor-serveis-educatius/library/inc/content/content-footer.php
+++ b/wp-content/themes/reactor-serveis-educatius/library/inc/content/content-footer.php
@@ -60,7 +60,7 @@ function reactor_do_footer_content() { ?>
         <div class="row">
             <div class="<?php reactor_columns( 12 ); ?>">
                 <div style="text-align:center" id="colophon">
-                    <p> <a target="_blank" href="http://www.xtec.cat/web/guest/avis">Avís legal</a> |
+                    <p> <a target="_blank" href="http://xtec.gencat.cat/ca/condicions-us">Avís legal</a> |
                     <a target="_blank" href="http://agora.xtec.cat/nodes/">Sobre el web</a> |
                     <span class="copyright">&copy;<?php echo date_i18n('Y'); ?>  Generalitat de Catalunya | </span>
                     <span class="site-source">Fet amb <a href=http://wordpress.org/>WordPress</a></span></p>


### PR DESCRIPTION
S'ha substituït l'enllaç de l'avís legal tant a reactor-primaria-1 com a serveis-educatius (Trello #1073)