### PR TITLE
Added register in wp_options to keep the number of visits and get the…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ Changes in progress
 - Mailer lib: Added latest changes
 - Google Analyticator: Upgraded to version 6.4.9.6 (Trello #994)
 - Email Subscribers: Added version 2.9.2 with first version of XTEC changes (Trello #833)
+- XTEC-stats: Added register in wp_options to keep the number of visits and get the information from there (Trello #1098)
+- XTEC-stats: Changed counting to include visits to wp-admin (Trello #1098)
 
 
 

--- a/wp-content/plugins/xtec-stats/xtec-stats.php
+++ b/wp-content/plugins/xtec-stats/xtec-stats.php
@@ -58,33 +58,29 @@ class Xtec_stats_widget extends WP_Widget {
         return $instance;
 	}
 
-	// Get DDBB results
-	function getStats($instance) {
-		global $wpdb;
-
-		$query = "SELECT count(*) AS Total FROM wp_stats
-				WHERE uri NOT LIKE('%wp-cron%')
-				AND uri NOT LIKE('%wp-admin%')";
-
-		$result = $wpdb->get_results($query);
-		$total = $result[0]->Total;
-
-		return $total;
-	}
-
 	// outputs the content of the widget
 	function widget($args, $instance) {
-		extract( $args );
-		echo $before_widget;
 
-		$total = $this->getStats($instance);
+        $before_widget = $args['before_widget'];
+        $after_widget = $args['after_widget'];
 
-		if (!empty($instance['title'])){
-			echo $before_title . esc_html($instance['title']) . $after_title;
-		}
-		echo '<div class="xtec-stats">';
-		echo $total;
-		echo '</div>';
-		echo $after_widget;
-	}
+        $visits = get_option('xtec-stats-visits');
+
+        echo $before_widget;
+
+        if (!empty($instance['title'])) {
+            $before_title = $args['before_title'];
+            $after_title = $args['after_title'];
+
+            echo $before_title . esc_html($instance['title']) . $after_title;
+        }
+        
+        echo '<div class="xtec-stats">';
+        echo $visits;
+        echo '</div>';
+        
+        echo $after_widget;
+        
+        return ;
+    }
 }


### PR DESCRIPTION
Comprovar que el widget d'estadístiques segueix funcionant, que manté el seu valor i que apareix un registre anomenat xtec-stats-visits a wp_options que conté el valor que es mostra per pantalla més 1 (això és degut a que primer s'agafa el valor i després s'incrementa)