### PR TITLE
Allow shortcodes into description to category, tags and taxonomies

### DIFF
--- a/wp-content/mu-plugins/agora-functions.php
+++ b/wp-content/mu-plugins/agora-functions.php
@@ -795,3 +795,11 @@ function translate_roles () {
     return ;
 }
 add_action( 'widget_visibility_roles', 'translate_roles' );
+
+/**
+ * Charge shortcodes into description to category, tags and taxonomies
+ *
+ * @author Xavi Nieto
+ */
+add_filter( 'term_description', 'shortcode_unautop');
+add_filter( 'term_description', 'do_shortcode');


### PR DESCRIPTION
Permetre afegir shortcodes i que es visualitzin als camps de descripció de categories, tags i taxonomies.
Per provar-ho podeu fer-ho amb:

```
calendar

[gcal id="145"]


carrusel

[slideshow_deploy id='142']
```


