### PR TITLE
Wip suggest labels

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ development home at https://github.com/projectestac/agora_nodes
 
 Changes in progress
 ---------------------------------------------------------------------------------------
-- Upgraded WordPress to version 4.5.2 (Trello #1272)
+- Upgraded WordPress to version 4.5.3 (Trello #1272)
 - Reviewed embed support in kses to let contributors add Picasa web albums (Trello #1182)
 - BuddyPress Group Email Subscription: Converted to submodule and updated to 3.6.1 (Trello #1042)
 - enllacos-educatius: Replaced Ministry of Education link
@@ -14,6 +14,7 @@ Changes in progress
 - wordpress-php-info: Upgraded from version 14.12 to version 15
 - mu-common: Deactivate pingback to avoid attacks to other sites (Trello #1275)
 - mu-common: Removed fix for post thumbnails broken due to upgrading to WP 4.4. No longer necessary in WP 4.5
+- buddypress-docs: Suggest labels when adding new documents (Trello #1228)
 
 
 Changes 16.05.03

--- a/wp-content/mu-plugins/agora-functions.php
+++ b/wp-content/mu-plugins/agora-functions.php
@@ -795,3 +795,27 @@ function translate_roles () {
     return ;
 }
 add_action( 'widget_visibility_roles', 'translate_roles' );
+
+/**
+ * Suggest labels to buddypress-docs
+ *
+ * @author Xavi Nieto
+ */
+function suggest_label() {
+    $term = '%'.strtolower( $_GET['term'] ).'%';
+    $suggestions = [];
+
+    global $wpdb;
+    $results = $wpdb->get_results($wpdb->prepare("SELECT name, slug FROM wp_terms INNER JOIN wp_term_taxonomy ON wp_terms.term_id = wp_term_taxonomy.term_id  WHERE  name LIKE '%s' AND wp_term_taxonomy.taxonomy = 'bp_docs_tag'",$term));
+
+    foreach( $results as $result ){
+        $suggestions[] = $result->name;
+    }
+
+    $response = json_encode( $suggestions );
+    echo $response;
+    exit();
+}
+
+add_action( 'wp_ajax_suggest_label', 'suggest_label' );
+add_action( 'wp_ajax_nopriv_suggest_label', 'suggest_label' );


### PR DESCRIPTION
Implementada la funcionalitat per quan s'afegeixen etiquetes als documents, apareguin suggerències basades en anteriors etiquetes abans introduïdes.

Concretament esta basades en les anteriors etiquetes que assignades a documents.
La suggerència apareix al introduir un primer caràcter al text-area d'etiquetes.

Es poden afegir múltiples valors.

Només cal afegir aquest commit:
https://github.com/projectestac/agora_nodes/pull/425/commits/820df5a094dded5cc38f41afa5ac82ca508053f9