### PR TITLE
Url to acces documents buddypress doc, use https protocol

### DIFF
--- a/wp-content/mu-plugins/agora-functions.php
+++ b/wp-content/mu-plugins/agora-functions.php
@@ -361,25 +361,29 @@ add_action('edit_page_form', 'force_post_title');
 
 /**
  * To avoid error uploading files from HTTP pages
- * @return string Create forums URL always with HTTPS
+ * @return string Create forums and docs URL always with HTTPS
  * @author Sara Arjona
+ * @author Xavier Nieto
  */
-function bbp_get_forum_permalink_filter($permalink) {
+function bbp_get_forum_doc_permalink_filter($permalink) {
 	
 	$url = $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"];
 	
-	if ( strpos($url,'forum') !== false) {
+	if ( strpos($url,'forum') !== false || strpos($url,'docs') !== false ) {
 		return preg_replace('/^http:/i', 'https:', $permalink);
 	}else {
 		return preg_replace('/^https:/i', 'http:', $permalink);
 	}
 }
 
-add_filter('bbp_get_forum_permalink', 'bbp_get_forum_permalink_filter');
-add_filter('bbp_get_topic_permalink', 'bbp_get_forum_permalink_filter');
-add_filter('bbp_get_reply_permalink', 'bbp_get_forum_permalink_filter');
-add_filter('bbp_get_topic_stick_link', 'bbp_get_forum_permalink_filter');
-add_filter('bp_get_group_permalink', 'bbp_get_forum_permalink_filter');
+add_filter('bbp_get_forum_permalink', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bbp_get_topic_permalink', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bbp_get_reply_permalink', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bbp_get_topic_stick_link', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bp_get_group_permalink', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bp_docs_get_doc_permalink', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bp_docs_get_tag_link_url', 'bbp_get_forum_doc_permalink_filter');
+add_filter('bp_docs_get_doc_link', 'bbp_get_forum_doc_permalink_filter');
 
 /**
  * Disable Add_To_Any Module widgets if user is not xtecadmin


### PR DESCRIPTION
- Quan s'accedeix a l'apartat amb documents del buddypress doc, hem fet que s'executi sota el protocol https, per tal de quan el pugin arxius no hi hagi conflictes amb els protocols.

- Per tal de realitzar les proves, cal accedir a nodes -> node concret i accedir a documents. 
- Comprovar que al navegar pels diferents documents, sempre es navega amb https. En qualsevol document provar a pujar un fitxer multimèdia i desar-ho.