### PR TITLE
Fix sintax line.60 javascript xtec-stats.js

### DIFF
--- a/wp-content/plugins/xtec-stats/js/xtec-stats.js
+++ b/wp-content/plugins/xtec-stats/js/xtec-stats.js
@@ -57,7 +57,7 @@ jQuery(document).ready(function(e){
 		jQuery('#xtec-stats-form-search').submit();
 	});
 
-	jQuery('input[name=search_type').on('change',function(e){
+	jQuery('input[name="search_type"]').on('change',function(e){
 
 		if(typeof xtec_stats_username === 'undefined'){
 			xtec_stats_username = 'username';
@@ -66,8 +66,6 @@ jQuery(document).ready(function(e){
 		if(typeof xtec_stats_content === 'undefined'){
 			xtec_stats_content = 'content';
 		}
-
-		console.log(xtec_stats_username,xtec_stats_content);
 
 		xtec_stats_change_placeholder(e,xtec_stats_username,xtec_stats_content);
 	});


### PR DESCRIPTION
Corregit error de sintaxis de jQuery a l'arxiu xtec-stats.js

Provar:

Accedir a **Eines** | **Registres** i amb la consola del navegador comprovar que no hi ha errors.