### PR TITLE
Wip fix bugs calendar booking

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ Work in progress
 - mu-common: Fixed default comment status. Restored default action about comment status parameter (Trello #1365)
 - mu-common: Added Automatic creation of featured image (Imatge resum) (Trello #1284)
 - xtec-stats: Fixed Javascript error in Safari in statistics page (Trello #1361)
+- xtec-booking: Fixed size image in modal window with the booking details (Trello #1399)
+- xtec-booking: Fixed styles in day view (Trello #1399)
 
 
 Changes 16.09.19

--- a/wp-content/plugins/xtec-booking/css/xtec-booking.css
+++ b/wp-content/plugins/xtec-booking/css/xtec-booking.css
@@ -239,6 +239,11 @@ strong.xtec_booking_color{
 	margin-top: 10px;
 }
 
+#modalContent > img{
+	max-width: 560px;
+	max-height: 340px;
+}
+
 span.weekdays{
 	font-weight: bold;
 }

--- a/wp-content/plugins/xtec-booking/css/xtec-booking.css
+++ b/wp-content/plugins/xtec-booking/css/xtec-booking.css
@@ -259,7 +259,8 @@ span.weekdays{
 }
 .day-highlight.dh-event-orange:hover,
 .day-highlight.dh-event-orange {
-	background-color:  #DF8A48 !important;
+	border-color: #DF8A48 !important;
+	background-color:  #ffc67f !important;
 }
 
 .event-pink {
@@ -267,7 +268,8 @@ span.weekdays{
 }
 .day-highlight.dh-event-pink:hover,
 .day-highlight.dh-event-pink {
-	background-color:  #ff6bd2 !important;
+	border-color: #ff6bd2;
+	background-color:  #ffe3eb;
 }
 
 .event-brown {
@@ -275,17 +277,19 @@ span.weekdays{
 }
 .day-highlight.dh-event-brown:hover,
 .day-highlight.dh-event-brown {
-	background-color:  #8B4500 !important;
+	border-color:  #8B4500 !important;
+	background-color:  #e1c38f !important;
 }
 
 .event-lightBlue{
 	background-color: #7AE7BF !important;
 }
-.day-highlight.dh-event-brown:hover,
-.day-highlight.dh-event-brown {
-	background-color:  #7AE7BF !important;
+.day-highlight.dh-event-lightBlue:hover,
+.day-highlight.dh-event-lightBlue {
+	border-color:  #7AE7BF !important;
+	background-color:  #d3e1ff !important;
 }
 
-div.pull-left.day-event.day-highlight.dh-event-important span.cal-hours{
+div.pull-left.day-event.day-highlight span.cal-hours{
 	display: none;
 }


### PR DESCRIPTION
1. Corregida la visualització d'una imatge gran a la finestra modal de la descripció dels events al calendari.
2. Corregida la visualització dels colors seleccionats als recursos a la vista diaria del calendari.
3. Corregit amagar la duplicació d'hores a la vista diaria del calendari.

Proves:

1. Afegir una imatge gran (`https://i.ytimg.com/vi/mT2TBN_etBs/maxresdefault.jpg`) i comprovar que es visualitza correctament dintre de la finestra modal.
2. Provar els diferents colors a la vista diaria de calendari, per comprovar que son els escollits.
3. Comprovar amb qualsevol seleccionat que les hores en color negre en la capseta de la vista diaria del calendari no son visibles.