### PR TITLE
Not allow change role for xtecadmin user

### DIFF
--- a/wp-admin/users.php
+++ b/wp-admin/users.php
@@ -137,7 +137,15 @@ case 'promote':
 		}
 
 		$user = get_userdata( $id );
+		// XTEC ************ AFEGIT - cannot be change role for Xtecadmin
+		// 2016.10.19 @xaviernietosanchez
+		if ( is_super_admin($id) !== true ){
+		//************ FI
 		$user->set_role( $role );
+		// XTEC ************ AFEGIT - cannot be change role for Xtecadmin
+		// 2016.10.19 @xaviernietosanchez
+		}
+		//************ FI
 	}
 
 	wp_redirect(add_query_arg('update', $update, $redirect));


### PR DESCRIPTION
No permetre canviar el rol d'Administrador a l'usuari "xtecadmin".

Proves:

- Accedir com administrador al panell.
- Anar a usuaris | tots els usuaris
- Provar a canviar el rol de l'xtecadmin a través de la modificació massiva.