### PR TITLE
Delete incorrect icon favicon

### DIFF
--- a/wp-content/themes/reactor/header.php
+++ b/wp-content/themes/reactor/header.php
@@ -21,11 +21,18 @@
     <?php wp_head(); reactor_head(); ?>
 
     <?php
+    // XTEC ************* ELIMINAT - Delete incorrect icon favicon
+    // 2016.10.25 @xaviernietosanchez
+    /*
         $favicon = reactor_option("favicon_image");
         if (!$favicon)
             $favicon = get_stylesheet_directory_uri()."/favicon.ico";
+
     ?>
     <link rel="shortcut icon" href="<?php echo $favicon; ?>"/>
+    */
+    // ************* FI
+    ?>
 </head>
 
 <body <?php body_class(); ?>>


### PR DESCRIPTION
Esborrar la duplicació de l'etiqueta del favicon.

Proves:

- Cal fer una revisió en les diferents aparences de Nodes.
- Cal fer proves amb el favicon que ve per defecte i provar a canviar-ho.