### PR TITLE
Delete incorrect icon favicon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Changes in progress
 - add-to-any: Upgraded plugin from version 1.7 to 1.7.1 (Trello #1441)
 - add-to-any: Added support for featured image (imatge resum) when sharing to facebook (Trello #1283)
 - xtec-booking: Improved colors for spaces and fixed max size of images (Trello #1420)
+- Theme reactor: Deleted duplicated favicon (Trello #1419)
 
 
 Changes 16.10.24

--- a/wp-content/themes/reactor/header.php
+++ b/wp-content/themes/reactor/header.php
@@ -18,14 +18,11 @@
     <link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet' type='text/css'>
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
 
-    <?php wp_head(); reactor_head(); ?>
-
     <?php
-        $favicon = reactor_option("favicon_image");
-        if (!$favicon)
-            $favicon = get_stylesheet_directory_uri()."/favicon.ico";
+        wp_head();
+        reactor_head();
     ?>
-    <link rel="shortcut icon" href="<?php echo $favicon; ?>"/>
+
 </head>
 
 <body <?php body_class(); ?>>


### PR DESCRIPTION
Esborrar la duplicació de l'etiqueta del favicon.

Proves:
- Cal fer una revisió en les diferents aparences de Nodes.
- Cal fer proves amb el favicon que ve per defecte i provar a canviar-ho.
