### PR TITLE
Fix capabilities to xtec-teacher.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,7 +43,6 @@
 [submodule "wp-content/plugins/email-subscribers"]
 	path = wp-content/plugins/email-subscribers
 	url = https://github.com/projectestac/wordpress-email-subscribers.git
-
 [submodule "wp-content/plugins/xtec-ldap-login"]
 	path = wp-content/plugins/xtec-ldap-login
 	url = https://github.com/projectestac/wordpress-xtec-ldap-login.git

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Changes in progress
 - add-to-any: Upgraded plugin from version 1.7 to 1.7.1 (Trello #1441)
 - add-to-any: Added support for featured image (imatge resum) when sharing to facebook (Trello #1283)
 - xtec-booking: Improved colors for spaces and fixed max size of images (Trello #1420)
+- xtec-booking: Role teacher can no longer edit posts edited by admins or editors, but can still edit bookings (Trello #1421)
 - Theme reactor: Deleted duplicated favicon (Trello #1419)
 
 

--- a/wp-content/plugins/xtec-booking/includes/actions_calendar.php
+++ b/wp-content/plugins/xtec-booking/includes/actions_calendar.php
@@ -127,6 +127,8 @@ function xtec_booking_active_plugin(){
     $roleAdmin->add_cap('delete_posts_bookings');
     $roleAdmin->add_cap('delete_pages_bookings');
     $roleAdmin->add_cap('publish_posts_bookings');
+    $roleAdmin->add_cap('edit_published_posts_bookings');
+    $roleAdmin->add_cap('delete_published_posts_bookings');
 
     // Add capabilities to role Editor
 	$roleEditor = get_role('editor');
@@ -134,6 +136,8 @@ function xtec_booking_active_plugin(){
     $roleEditor->add_cap('delete_posts_bookings');
     $roleEditor->add_cap('delete_pages_bookings');
     $roleEditor->add_cap('publish_posts_bookings');
+    $roleEditor->add_cap('edit_published_posts_bookings');
+    $roleEditor->add_cap('delete_published_posts_bookings');
 
 	// Add capabilities to role Author
 	$roleAuthor = get_role('author');
@@ -142,15 +146,21 @@ function xtec_booking_active_plugin(){
     $roleAuthor->add_cap('delete_posts_bookings');
     $roleAuthor->add_cap('publish_posts_bookings');
     $roleAuthor->add_cap('delete_pages');
+    $roleAuthor->add_cap('edit_published_posts_bookings');
+    $roleAuthor->add_cap('delete_published_posts_bookings');
 
     // Add capabilities to role Teacher
-	$roleTeacher = get_role('xtec_teacher');
-	if ( ! is_null( $roleTeacher ) ){
-		$roleTeacher->add_cap('delete_pages_bookings');
-		$roleTeacher->add_cap('edit_posts_bookings');
-	    $roleTeacher->add_cap('delete_posts_bookings');
-	    $roleTeacher->add_cap('publish_posts_bookings');
-	}
+    $roleTeacher = get_role('xtec_teacher');
+    if ( ! is_null( $roleTeacher ) ) {
+        $roleTeacher->add_cap('delete_pages_bookings');
+        $roleTeacher->add_cap('edit_posts_bookings');
+        $roleTeacher->add_cap('delete_posts_bookings');
+        $roleTeacher->add_cap('publish_posts_bookings');
+        $roleTeacher->remove_cap('edit_published_posts');
+        $roleTeacher->remove_cap('delete_published_posts');
+        $roleTeacher->add_cap('edit_published_posts_bookings');
+        $roleTeacher->add_cap('delete_published_posts_bookings');
+    }
 
 	// Add capabilities to role Contributor
 	$roleContributor = get_role('contributor');
@@ -169,6 +179,8 @@ function xtec_booking_deactive_plugin(){
     $roleAdmin->remove_cap('delete_posts_bookings');
     $roleAdmin->remove_cap('delete_pages_bookings');
     $roleAdmin->remove_cap('publish_posts_bookings');
+    $roleAdmin->remove_cap('edit_published_posts_bookings');
+    $roleAdmin->remove_cap('delete_published_posts_bookings');
 
     // Remove capabilities to role Editor
 	$roleEditor = get_role('editor');
@@ -176,6 +188,8 @@ function xtec_booking_deactive_plugin(){
     $roleEditor->remove_cap('delete_posts_bookings');
     $roleEditor->remove_cap('delete_pages_bookings');
     $roleEditor->remove_cap('publish_posts_bookings');
+    $roleEditor->remove_cap('edit_published_posts_bookings');
+    $roleEditor->remove_cap('delete_published_posts_bookings');
 
 	// Remove capabilities to role Author
 	$roleAuthor = get_role('author');
@@ -184,14 +198,20 @@ function xtec_booking_deactive_plugin(){
     $roleAuthor->remove_cap('delete_posts_bookings');
     $roleAuthor->remove_cap('publish_posts_bookings');
     $roleAuthor->remove_cap('delete_pages');
+    $roleAuthor->remove_cap('edit_published_posts_bookings');
+    $roleAuthor->remove_cap('delete_published_posts_bookings');
 
     // Add capabilities to role Teacher
 	$roleTeacher = get_role('xtec_teacher');
 	if ( ! is_null( $roleTeacher ) ){
-		$roleTeacher->remove_cap('delete_pages_bookings');
-		$roleTeacher->remove_cap('edit_posts_bookings');
-	    $roleTeacher->remove_cap('delete_posts_bookings');
-	    $roleTeacher->remove_cap('publish_posts_bookings');
+        $roleTeacher->remove_cap('delete_published_posts');
+        $roleTeacher->remove_cap('edit_published_posts');
+        $roleTeacher->remove_cap('delete_pages_bookings');
+        $roleTeacher->remove_cap('edit_posts_bookings');
+        $roleTeacher->remove_cap('delete_posts_bookings');
+        $roleTeacher->remove_cap('publish_posts_bookings');
+        $roleTeacher->remove_cap('edit_published_posts_bookings');
+        $roleTeacher->remove_cap('delete_published_posts_bookings');
 	}
 
 	// Add capabilities to role Contributor

--- a/wp-content/plugins/xtec-booking/xtec-booking.php
+++ b/wp-content/plugins/xtec-booking/xtec-booking.php
@@ -47,7 +47,9 @@ function create_post_type() {
 		'delete_pages' 	=> 'delete_pages_bookings',
 		'edit_posts' 	=> 'edit_posts_bookings',
 		'delete_posts' 	=> 'delete_posts_bookings',
-		'publish_posts' => 'publish_posts_bookings'
+		'publish_posts' => 'publish_posts_bookings',
+		'edit_published_posts' => 'edit_published_posts_bookings',
+		'delete_published_posts' => 'delete_published_posts_bookings'
 	);
 
 	if ( in_array( 'administrator', (array) $user->roles ) || in_array( 'editor', (array) $user->roles ) ) {


### PR DESCRIPTION
Corregides les capabilities dels usuaris amb rol xtec-teacher, per tindre el mateix comportament i opcions que els usuaris amb rol contributor fora de l'aplicació de reserves.

Per provar-ho cal:

- Canviar a la branca
- Desactivar i tornar a activar l'aplicació de reserves (no es perden les reserves realitzades ni els espais/equips afegits)
- Comprovar que l'aplicació de reserves continua tenint el mateix comportament (poden fer, publicar i modificar qualsevol reserva propia)
- Comprovar que al crear un article, i després de ser validat per un administrador / editor, l'usuari amb el rol xtec-teacher, perd el control i només el pot visualitzar.