### PR TITLE
Replace colors and fix max size to image

### DIFF
--- a/wp-content/plugins/xtec-booking/css/xtec-booking.css
+++ b/wp-content/plugins/xtec-booking/css/xtec-booking.css
@@ -239,7 +239,7 @@ strong.xtec_booking_color{
 	margin-top: 10px;
 }
 
-#modalContent > img{
+#modalContent img{
 	max-width: 560px;
 	max-height: 340px;
 }
@@ -264,12 +264,12 @@ span.weekdays{
 }
 
 .event-pink {
-  	background-color: #ff6bd2 !important;
+  	background-color: #ff789e !important;
 }
 .day-highlight.dh-event-pink:hover,
 .day-highlight.dh-event-pink {
-	border-color: #ff6bd2;
-	background-color:  #ffe3eb;
+	border-color: #ff789e !important;
+	background-color:  #ffe3eb !important;
 }
 
 .event-brown {
@@ -282,12 +282,17 @@ span.weekdays{
 }
 
 .event-lightBlue{
-	background-color: #7AE7BF !important;
+	background-color: #4cdefd !important;
 }
 .day-highlight.dh-event-lightBlue:hover,
 .day-highlight.dh-event-lightBlue {
-	border-color:  #7AE7BF !important;
-	background-color:  #d3e1ff !important;
+	border-color:  #4cdefd !important;
+	background-color:  #dbf8ff !important;
+}
+
+/* REPLACE COLOR ORIGINAL */
+.dh-event-special{
+	background-color:  #ecd9f8 !important;
 }
 
 div.pull-left.day-event.day-highlight span.cal-hours{


### PR DESCRIPTION
- Substituir els colors de fons i vores a la vista de dies del calendari de reserves.

**Modificar el blau cel:**
Vora: 4cdefd
Fons: dbf8ff

**Modificar rosa:**
Vora: ff789e

**Modificar lila:**
Fons: ecd9f8
- Corregir les dimensions màximes d'una imatge afegida a la descripció d'una - reserva per evitar que sobresurti de la finestra modal.

Proves:
- Cal crear un espai o equip i crear reserves sobre ell.

**Proves color**:
- Cal canviar el color assignat al equip o espai i accedir a les diferents vistes del calendari.

**Proves imatge**:
- Cal afegir una imatge gran a la descripció d'una reserva i veure com es comporta en la finestra modal que surt al fer clic sobre la reserva a la vista de calendari.
