### PR TITLE
Allow mail direction into headers icons

### DIFF
--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -44,11 +44,23 @@ add_action('wp_head', 'reactor_do_reactor_head', 1);
  */
 function show_header_icon($options, $icon_number) {
     $url = parse_url($options['link_icon' . $icon_number]);
-    if (($url['scheme'] == 'https') || ($url['scheme'] == 'http')) {
+
+    $currentDomain = str_replace( 'www.', '', $_SERVER['HTTP_HOST'] );
+
+    // Change target link if is the same domain
+    if ( str_replace( 'www.', '', $url['host'] ) == $currentDomain ){
+        $link = $options['link_icon' . $icon_number];
+        $target = '_self';
+    }else if ( ( $url['scheme'] == 'https' ) || ( $url['scheme'] == 'http' ) ) {
         $link = $options['link_icon' . $icon_number];
         $target = set_target($link);
     } else {
+        // Allow include a mail direction instead of a url
+        if ( preg_match('/^[_a-z0-9-]+(.[_a-z0-9-]+)*@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,4})$/', $options['link_icon' . $icon_number]) ){
+            $link = "mailto:" . $options['link_icon' . $icon_number];
+        } else {
         $link = get_home_url() . '/' . $options['link_icon' . $icon_number];
+        }
         $target = '_self';
     }
 

--- a/wp-content/themes/reactor-serveis-educatius/custom-tac/menu-principal.php
+++ b/wp-content/themes/reactor-serveis-educatius/custom-tac/menu-principal.php
@@ -97,11 +97,22 @@ function menu_etiquetes() {
 
         $url = parse_url($options['link_icon' . $i]);
 
-        if (($url['scheme'] == 'https') || ($url['scheme'] == 'http')) {
+        $currentDomain = str_replace('www.', '', $_SERVER['HTTP_HOST']);
+
+        // Change target link if is the same domain
+        if ( str_replace('www.', '', $url['host']) == $currentDomain ){
+            $link = $options['link_icon' . $i];
+            $target = '_self';
+        }else if (($url['scheme'] == 'https') || ($url['scheme'] == 'http')) {
             $link = $options['link_icon' . $i];
             $target = set_target($link);
         } else {
+            // Allow include a mail direction instead of a url
+            if ( preg_match('/^[_a-z0-9-]+(.[_a-z0-9-]+)*@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,4})$/', $options['link_icon' . $i]) ){
+                $link = "mailto:" . $options['link_icon' . $i];
+            } else {
             $link = get_home_url() . '/' . $options['link_icon' . $i];
+            }
             $target = '_self';
         }
 


### PR DESCRIPTION
Hem modificat el codi per què permeti afegir una direcció de correu electrònic en les icones de capçalera:

Cal modificar una de les icones en l'enllaç i prova amb:

- Correu electrònic: Al clicar en l'enllaç a d'actuar com un "mailto"
- Url absoluta amb el mateix domini: Al clicar actua com un link a un enllaç a la mateixa pestanya.
- Url relativa: Al clicar actua com un link a un enllaç a la mateixa pestanya.
- Url absoluta amb un domini diferent: Al clicar actua com un link a un enllaç a una altre pestanya.

