### PR TITLE
Add field mail to Fitxa del Centre, and modify usability desktop and mobile versions. Change usability map link.

### DIFF
--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -194,12 +194,60 @@ function reactor_do_title_logo()
     <div id="box-grid" class="box-grid large-2 small-12 columns">
         <div class="box-content-grid row icon-box">
             <div class="topicons large-4 small-4 columns show-for-small">
-                <button id="icon-email" onclick="window.location.href='mailto:<?php echo reactor_option('emailCentre'); ?>'" class="dashicons dashicons-email">
+                <?php
+                    // Get type contact by modify behavior
+                    $contacte_mobile = reactor_option('correuCentre');
+                    $correu_centre_enabled = false;
+                    if ( empty($contacte_mobile) ){
+                        $contacte_mobile = reactor_option('contacteCentre');
+                    } else if( $contacte_mobile != '' ) {
+                        $contacte_mobile = "mailto:" . $contacte_mobile;
+                        $correu_centre_enabled = true;
+                    }
+
+                    if( $correu_centre_enabled === true ){
+                ?>
+                <button id="icon-email" onclick="window.location.href='<?php echo $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php 
+                    } else if ( ! empty($contacte_mobile) ){
+                        $currentDomain = get_home_url();
+                        $searchDomain = array('http://','https://');
+                        $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                        $contacteDomain = str_replace($searchDomain,'',$contacte_mobile);
+                        if ( strpos($contacteDomain,$currentDomain) !== false ){
+                ?>
+                <button id="icon-email" onclick="window.location.href='<?php echo $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php
+                        } else if ( strpos($contacte_mobile,'http') === false ){
+                            if ( strpos($contacte_mobile,'.') !== false ){
+                ?>
+                <button id="icon-email" onclick="window.open('<?php echo "http://" . $contacte_mobile; ?>','_blank')" class="dashicons dashicons-email">
+                <?php
+                            } else {
+                ?>
+                <button id="icon-email" onclick="window.location.href='<?php echo $currentDomain . $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php
+                            }
+                        } else {
+                ?>
+
+                <button id="icon-email" onclick="window.open('<?php echo $contacte_mobile; ?>','_blank')" class="dashicons dashicons-email">
+                <?php   } ?>
+                <?php } else { ?>
+                <button id="icon-email" class="dashicons dashicons-email">
+                <?php } ?>
                 <span class="text_icon">Correu</span>
                 </button>
             </div>
             <div class="topicons large-4 small-4 columns show-for-small">
-                <button id="icon-maps" title="Mapa" onclick="window.location.href='<?php echo reactor_option('googleMaps'); ?>'" class="dashicons dashicons-location-alt">
+                <?php 
+                    // Get if GoogleMaps is empty or not by modify behavior
+                    if ( ! empty(reactor_option('googleMaps')) ){ 
+                ?>
+                <button id="icon-maps" title="Mapa" onclick="window.open('<?php echo reactor_option('googleMaps'); ?>','_blank')" class="dashicons dashicons-location-alt">
+                <?php } else { ?>
+                <button id="icon-maps" title="Mapa" class="dashicons dashicons-location-alt">
+                <?php } ?>
                 <span class="text_icon">Mapa</span>
                 </button>
             </div>

--- a/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
@@ -357,18 +357,33 @@ if ( !function_exists('reactor_customize_register') ) {
 					'priority' => 7,
 				 ) );
 
-			$wp_customize->add_setting('reactor_options[emailCentre]', array(
+			// Field to contact page
+			$wp_customize->add_setting('reactor_options[contacteCentre]', array(
 				'default'    => "",
 				'type'       => 'option',
 				'capability' => 'manage_options',
 				'transport'  => 'postMessage',
 			 ) );
-				$wp_customize->add_control('reactor_options[emailCentre]', array(
+				// Field to contact page
+				$wp_customize->add_control('reactor_options[contacteCentre]', array(
 					'label'    => __('Contacte principal', 'reactor'),
 					'section'  => 'reactor_customizer_idcentre',
-                                        'description' => 'Email o pàgina de contacte',
+                                        'description' => 'Pàgina de contacte (prioritari al web)',
 					'priority' => 8,
-				 ) );
+				) );
+
+			// Add field mail
+			$wp_customize->add_setting('reactor_options[correuCentre]', array(
+				'default'    => "",
+				'type'       => 'option',
+				'capability' => 'manage_options',
+				'transport'  => 'postMessage',
+			 ) );
+			$wp_customize->add_control('reactor_options[correuCentre]', array(
+				'section'  => 'reactor_customizer_idcentre',
+                                    'description' => 'Correu electrònic (prioritari al mòbil)',
+				'priority' => 9,
+			 ) );
 
                         global $colors_nodes;
 

--- a/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
@@ -22,7 +22,21 @@ class Logo_Centre_Widget extends WP_Widget {
             echo '<h4 class="widget-title">' . $title . '</h4>';
         }
 
-        $contacte = (strstr(reactor_option('emailCentre'), '@')) ? "mailto:" . reactor_option('emailCentre') : reactor_option('emailCentre');
+        // Check options to print url link or mailto link
+        $contacteCentre = reactor_option('contacteCentre');
+        $correuCentre = reactor_option('correuCentre');
+        $contacte_mobile_enabled = false;
+
+        ( ! empty($contacteCentre) ) ? $contacte = $contacteCentre : $contacte = false;
+        ( ! empty($correuCentre) ) ? $contacte_mobile = "mailto:" . $correuCentre : $contacte_mobile = false;
+
+        if ( $contacte == false && $contacte_mobile != false ){
+            $contacte = $contacte_mobile;
+            $contacte_mobile_enabled = true;
+        }else if ( $contacte_mobile == false && $contacte != false ){
+            $contacte_mobile = $contacte;
+        }
+
         ?>
         <div class="targeta_id_centre row">
             <?php list($postal_code, $locality) = explode(" ", reactor_option("cpCentre"), 1); ?>
@@ -44,10 +58,54 @@ class Logo_Centre_Widget extends WP_Widget {
                         <div class="tel">
                             <span><?php echo reactor_option('telCentre'); ?></span>
                         </div>
-                        <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
-                        <span class="pipe" >|</span> 
-                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php 
+                            // Check if googleMaps is empty to show or not
+                            $showPipe = false;
+                            if ( ! empty(reactor_option('googleMaps') )){ 
+                                $showPipe = true;
+                        ?>
+                        <a id="tar-mapa" target="_blank" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
+                        <?php } ?>
+                        <?php 
+                            // Check if $contacte is empty to show or not
+                            if ( $contacte != false && $contacte_mobile != false ){
+                                if( $showPipe == true ){
+                        ?>
+                        <span class="pipe" >|</span>
+                        <?php 
+                                } 
 
+                                if ( $contacte_mobile_enabled == true ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php 
+                                } else {
+                                    $currentDomain = get_home_url();
+                                    $searchDomain = array('http://','https://');
+                                    $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                                    $contacteDomain = str_replace($searchDomain,'',$contacte);
+                                    if ( strpos($contacteDomain,$currentDomain) !== false ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    } else if ( strpos($contacte,'http') === false ){
+                                        if ( strpos($contacte,'.') !== false ){
+                        ?>
+                                            <a id="tar-contacte" target="_blank" href="<?php echo esc_url("https://" . $contacte); ?>">contacte</a>
+                        <?php
+                                        } else {
+                        ?>
+                                            <a id="tar-contacte" href="<?php echo esc_url($currentDomain . $contacte); ?>">contacte</a>
+                        <?php
+                                        }
+                                    } else {
+                        ?>
+                        <a id="tar-contacte" target="_blank" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    }
+                                }
+                            }
+                        ?>
                     </div>		 
                 </div>	
             </div>		 

--- a/wp-content/themes/reactor-serveis-educatius/library/inc/customizer/customize.php
+++ b/wp-content/themes/reactor-serveis-educatius/library/inc/customizer/customize.php
@@ -338,18 +338,34 @@ if ( !function_exists('reactor_customize_register') ) {
 					'priority' => 7,
 				 ) );
 
-			$wp_customize->add_setting('reactor_options[emailCentre]', array(
+			// Field to contact page
+			$wp_customize->add_setting('reactor_options[contacteCentre]', array(
 				'default'    => "",
 				'type'       => 'option',
 				'capability' => 'manage_options',
 				'transport'  => 'postMessage',
 			 ) );
-				$wp_customize->add_control('reactor_options[emailCentre]', array(
+				// Field to contact page
+				$wp_customize->add_control('reactor_options[contacteCentre]', array(
 					'label'    => __('Contacte principal', 'reactor'),
 					'section'  => 'reactor_customizer_idcentre',
-                                        'description' => 'Email o pàgina de contacte',
+                                        'description' => 'Pàgina de contacte (prioritari al web)',
 					'priority' => 8,
-				 ) );
+				) );
+
+			// Add field mail
+			$wp_customize->add_setting('reactor_options[correuCentre]', array(
+				'default'    => "",
+				'type'       => 'option',
+				'capability' => 'manage_options',
+				'transport'  => 'postMessage',
+			 ) );
+			$wp_customize->add_control('reactor_options[correuCentre]', array(
+				'label'    => __('Email principal', 'reactor'),
+				'section'  => 'reactor_customizer_idcentre',
+                                    'description' => 'Correu electrònic (prioritari al mòbil)',
+				'priority' => 9,
+			 ) );
 
                         global $colors_nodes;
 

--- a/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
@@ -22,7 +22,21 @@ class Logo_Centre_Widget extends WP_Widget {
             echo '<h4 class="widget-title">' . $title . '</h4>';
         }
 
-        $contacte = (strstr(reactor_option('emailCentre'), '@')) ? "mailto:" . reactor_option('emailCentre') : reactor_option('emailCentre');
+        // Check options to print url link or mailto link
+        $contacteCentre = reactor_option('contacteCentre');
+        $correuCentre = reactor_option('correuCentre');
+        $contacte_mobile_enabled = false;
+
+        ( ! empty($contacteCentre) ) ? $contacte = $contacteCentre : $contacte = false;
+        ( ! empty($correuCentre) ) ? $contacte_mobile = "mailto:" . $correuCentre : $contacte_mobile = false;
+
+        if ( $contacte == false && $contacte_mobile != false ){
+            $contacte = $contacte_mobile;
+            $contacte_mobile_enabled = true;
+        } else if ( $contacte_mobile == false && $contacte != false ){
+            $contacte_mobile = $contacte;
+        }
+
         ?>
         <div class="targeta_id_centre row">
             <?php
@@ -62,10 +76,54 @@ class Logo_Centre_Widget extends WP_Widget {
                         <div class="tel">
                             <span><?php echo reactor_option('telCentre'); ?></span>
                         </div>
-                        <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
-                        <span class="pipe" >|</span> 
-                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php 
+                            // Check if googleMaps is empty to show or not
+                            $showPipe = false;
+                            if ( ! empty(reactor_option('googleMaps') )){
+                                $showPipe = true;
+                        ?>
+                        <a id="tar-mapa" target="_blank" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
+                        <?php } ?>
+                        <?php 
+                            // Check if $contacte is empty to show or not
+                            if ( $contacte != false && $contacte_mobile != false ){
+                                if( $showPipe == true ){
+                        ?>
+                        <span class="pipe" >|</span>
+                        <?php 
+                                } 
 
+                                if ( $contacte_mobile_enabled == true ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php 
+                                } else { 
+                                    $currentDomain = get_home_url();
+                                    $searchDomain = array('http://','https://');
+                                    $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                                    $contacteDomain = str_replace($searchDomain,'',$contacte);
+                                    if ( strpos($contacteDomain,$currentDomain) !== false ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php
+                                    } else if ( strpos($contacte,'http') === false ){
+                                        if ( strpos($contacte,'.') !== false ){
+                        ?>
+                                            <a id="tar-contacte" target="_blank" href="<?php echo esc_url("https://" . $contacte); ?>">contacte</a>
+                        <?php
+                                        } else {
+                        ?>
+                                            <a id="tar-contacte" href="<?php echo esc_url($currentDomain . $contacte); ?>">contacte</a>
+                        <?php
+                                        }
+                                    } else {
+                        ?>
+                        <a id="tar-contacte" target="_blank" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    }
+                                }
+                            }
+                        ?>
                     </div>		 
                 </div>	
             </div>		 


### PR DESCRIPTION
Hem modificat el codi per què permeti afegir una direcció de correu electrònic en les icones de capçalera:

Cal modificar una de les icones en l'enllaç i prova amb:

- Correu electrònic: Al clicar en l'enllaç a d'actuar com un "mailto"

**Casuística amb urls:**

- Si la base és agora.xtec.cat/nompropi:
- [http[s]://]agora.xtec.cat/nompropi/* s'obrirà a la mateixa finestra.
- [/] (on no ha de contenir cap ., perquè sinó voldrà dir que és un URL) s'obrirà a la mateixa finestra. Per exemple /activitat o activitat.
- La resta s'obriran totes en finestra nova. Per exemple:
[http[s]://]agora.xtec.cat/altrenompropi/*
[http[s]://]clic.xtec.cat/
[http[s]://]google.com/