### PR TITLE
Add field mail to Fitxa del Centre, and modify usability desktop and mobile versions. Change usability map link.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,7 @@ Changes in progress
 - buddypress: Upgraded plugin from 2.5.3 to 2.7.2 (Trello #1446)
 - buddypress-like: Upgraded plugin from 0.2 to 0.3 and converted into a submodule (Trello #1452)
 - buddypress-docs: Upgraded plugin from 1.9.0 to 1.9.2 (Trello #1442)
+- Themes reactor-primaria-1 and reactor-serveis-educatius: Added field email to Fitxa del Centre and modified behaviour of links for contact and map (Trello #1459)
 
 
 Changes 16.10.24

--- a/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/content/content-header.php
@@ -194,12 +194,83 @@ function reactor_do_title_logo()
     <div id="box-grid" class="box-grid large-2 small-12 columns">
         <div class="box-content-grid row icon-box">
             <div class="topicons large-4 small-4 columns show-for-small">
-                <button id="icon-email" onclick="window.location.href='mailto:<?php echo reactor_option('emailCentre'); ?>'" class="dashicons dashicons-email">
+                <?php
+
+                    // Get type contact by modify behavior
+                    $contacte_mobile = reactor_option('correuCentre');
+                    $correu_centre_enabled = false;
+                    if ( empty($contacte_mobile) ){
+                        $contacte_mobile = reactor_option('contacteCentre');
+                    } else if( $contacte_mobile != '' ) {
+                        $contacte_mobile = "mailto:" . $contacte_mobile;
+                        $correu_centre_enabled = true;
+                    }
+
+                    // Get home url
+                    $currentDomain = get_home_url();
+                    $searchDomain = array('http://','https://');
+                    $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                    $contacteDomain = str_replace($searchDomain,'',$contacte_mobile);
+
+                    if( $correu_centre_enabled === true ){
+                ?>
+                <button id="icon-email" onclick="window.location.href='<?php echo $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php 
+                    } else if ( ! empty($contacte_mobile) ){
+                        if ( strpos($contacteDomain,$currentDomain) !== false ){
+                ?>
+                            <button id="icon-email" onclick="window.location.href='<?php echo $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php
+                        } else if ( strpos($contacte_mobile,'http') === false ){
+                            if ( strpos($contacte_mobile,'.') !== false ){
+                ?>
+                                <button id="icon-email" onclick="window.open('<?php echo "http://" . $contacte_mobile; ?>','_blank')" class="dashicons dashicons-email">
+                <?php
+                            } else {
+                ?>
+                                <button id="icon-email" onclick="window.location.href='<?php echo $currentDomain . $contacte_mobile; ?>'" class="dashicons dashicons-email">
+                <?php
+                            }
+                        } else {
+                ?>
+                            <button id="icon-email" onclick="window.open('<?php echo $contacte_mobile; ?>','_blank')" class="dashicons dashicons-email">
+                <?php   } ?>
+                <?php } else { ?>
+                        <button id="icon-email" class="dashicons dashicons-email">
+                <?php } ?>
                 <span class="text_icon">Correu</span>
                 </button>
             </div>
             <div class="topicons large-4 small-4 columns show-for-small">
-                <button id="icon-maps" title="Mapa" onclick="window.location.href='<?php echo reactor_option('googleMaps'); ?>'" class="dashicons dashicons-location-alt">
+                <?php 
+                    // Get if GoogleMaps is empty or not by modify behavior
+                    $emptyMaps = reactor_option('googleMaps');
+                    if ( ! empty($emptyMaps) ){
+                        if ( strpos(reactor_option('googleMaps'),$currentDomain) !== false ){
+                ?>
+                            <button id="icon-maps" title="Mapa" onclick="window.location.href='<?php echo reactor_option('googleMaps'); ?>" class="dashicons dashicons-location-alt">
+                <?php
+                        } else if ( strpos(reactor_option('googleMaps'),'http') === false ){
+                            if ( strpos(reactor_option('googleMaps'),'.') !== false ){
+                ?>
+                                 <button id="icon-maps" title="Mapa" onclick="window.open('<?php echo "https://" . reactor_option('googleMaps'); ?>','_blank')" class="dashicons dashicons-location-alt">
+                <?php
+                            } else {
+                ?>
+                                <button id="icon-maps" title="Mapa" onclick="window.location.href='<?php echo $currentDomain . reactor_option('googleMaps'); ?>','_blank')" class="dashicons dashicons-location-alt">
+                <?php
+                            }
+                        } else {
+                ?>
+                            <button id="icon-maps" title="Mapa" onclick="window.open('<?php echo reactor_option('googleMaps'); ?>','_blank')" class="dashicons dashicons-location-alt">
+                <?php
+                        }
+                    } else {
+                ?>
+                        <button id="icon-maps" title="Mapa" class="dashicons dashicons-location-alt">
+                <?php
+                    }
+                ?>
                 <span class="text_icon">Mapa</span>
                 </button>
             </div>

--- a/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
+++ b/wp-content/themes/reactor-primaria-1/library/inc/customizer/customize.php
@@ -357,18 +357,33 @@ if ( !function_exists('reactor_customize_register') ) {
 					'priority' => 7,
 				 ) );
 
-			$wp_customize->add_setting('reactor_options[emailCentre]', array(
+			// Field to contact page
+			$wp_customize->add_setting('reactor_options[contacteCentre]', array(
 				'default'    => "",
 				'type'       => 'option',
 				'capability' => 'manage_options',
 				'transport'  => 'postMessage',
 			 ) );
-				$wp_customize->add_control('reactor_options[emailCentre]', array(
+				// Field to contact page
+				$wp_customize->add_control('reactor_options[contacteCentre]', array(
 					'label'    => __('Contacte principal', 'reactor'),
 					'section'  => 'reactor_customizer_idcentre',
-                                        'description' => 'Email o pàgina de contacte',
+                    'description' => " <a style='float:left;margin-top:-44px; margin-left:135px;height:0px;width:0px;font-style: normal;' target='_blank' href='http://agora.xtec.cat/moodle/moodle/mod/glossary/view.php?id=1741&mode=entry&hook=2681'> <br> (" . __('Ajuda','reactor') . ")</a>" . __('Pàgina de contacte','reactor'),
 					'priority' => 8,
-				 ) );
+				) );
+
+			// Add field mail
+			$wp_customize->add_setting('reactor_options[correuCentre]', array(
+				'default'    => "",
+				'type'       => 'option',
+				'capability' => 'manage_options',
+				'transport'  => 'postMessage',
+			 ) );
+			$wp_customize->add_control('reactor_options[correuCentre]', array(
+				'section'  => 'reactor_customizer_idcentre',
+                'description' => __('Adreça electrònica','reactor'),
+				'priority' => 9,
+			 ) );
 
                         global $colors_nodes;
 

--- a/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
@@ -22,7 +22,21 @@ class Logo_Centre_Widget extends WP_Widget {
             echo '<h4 class="widget-title">' . $title . '</h4>';
         }
 
-        $contacte = (strstr(reactor_option('emailCentre'), '@')) ? "mailto:" . reactor_option('emailCentre') : reactor_option('emailCentre');
+        // Check options to print url link or mailto link
+        $contacteCentre = reactor_option('contacteCentre');
+        $correuCentre = reactor_option('correuCentre');
+        $contacte_mobile_enabled = false;
+
+        ( ! empty($contacteCentre) ) ? $contacte = $contacteCentre : $contacte = false;
+        ( ! empty($correuCentre) ) ? $contacte_mobile = "mailto:" . $correuCentre : $contacte_mobile = false;
+
+        if ( $contacte == false && $contacte_mobile != false ){
+            $contacte = $contacte_mobile;
+            $contacte_mobile_enabled = true;
+        }else if ( $contacte_mobile == false && $contacte != false ){
+            $contacte_mobile = $contacte;
+        }
+
         ?>
         <div class="targeta_id_centre row">
             <?php list($postal_code, $locality) = explode(" ", reactor_option("cpCentre"), 1); ?>
@@ -44,10 +58,92 @@ class Logo_Centre_Widget extends WP_Widget {
                         <div class="tel">
                             <span><?php echo reactor_option('telCentre'); ?></span>
                         </div>
-                        <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
-                        <span class="pipe" >|</span> 
-                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php 
 
+                            // Get home url to check behavior target link
+                            $currentDomain = get_home_url();
+                            $searchDomain = array('http://','https://');
+                            $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                            $contacteDomain = str_replace($searchDomain,'',$contacte);
+
+                        // Check if googleMaps is empty to show or not
+                            $showPipe = false;
+                            $emptyMaps = reactor_option('googleMaps');
+                            if ( ! empty($emptyMaps)){
+                                $showPipe = true;
+                                if ( strpos(reactor_option('googleMaps'),$currentDomain) !== false ){
+                        ?>
+                                    <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a>
+                        <?php   
+                                } else if ( strpos(reactor_option('googleMaps'),'http') === false ){
+                                    if ( strpos(reactor_option('googleMaps'),'.') !== false ){
+                        ?>
+                                        <a id="tar-mapa" target="_blank" href="<?php echo "https://".reactor_option('googleMaps'); ?>">mapa</a>
+                        <?php
+                                    } else {
+                                        if ( substr ( trim(reactor_option('googleMaps')) , 0 , 1 ) == '/' ){
+                        ?>
+                                            <a id="tar-mapa" href=" <?php echo esc_url(get_home_url() . reactor_option('googleMaps')); ?>">mapa</a>
+                        <?php
+                                        } else {
+                        ?>
+                                            <a id="tar-mapa" href=" <?php echo esc_url(get_home_url() . '/' . reactor_option('googleMaps')); ?>">mapa</a>
+                        <?php
+                                        }
+                                    }
+                                } else {
+                        ?>
+                                    <a id="tar-mapa" target="_blank" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a>
+                        <?php
+                                }
+                            } 
+                        ?>
+                        <?php 
+                            // Check if $contacte is empty to show or not
+                            if ( $contacte != false && $contacte_mobile != false ){
+                                if( $showPipe == true ){
+                        ?>
+                                    <span class="pipe" >|</span>
+                        <?php 
+                                } 
+
+                                if ( $contacte_mobile_enabled == true ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php 
+                                } else {
+                                    $currentDomain = get_home_url();
+                                    $searchDomain = array('http://','https://');
+                                    $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                                    $contacteDomain = str_replace($searchDomain,'',$contacte);
+                                    if ( strpos($contacteDomain,$currentDomain) !== false ){
+                        ?>
+                        <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    } else if ( strpos($contacte,'http') === false ){
+                                        if ( strpos($contacte,'.') !== false ){
+                        ?>
+                                            <a id="tar-contacte" target="_blank" href="<?php echo esc_url("https://" . $contacte); ?>">contacte</a>
+                        <?php
+                                        } else {
+                                            if ( substr ( trim($contacte) , 0 , 1 ) == '/' ){
+                        ?>
+                                                <a id="tar-contacte" href="<?php echo esc_url($currentDomain . $contacte); ?>">contacte</a>
+                        <?php
+                                            } else {
+                        ?>
+                                                <a id="tar-contacte" href="<?php echo esc_url($currentDomain . '/' . $contacte); ?>">contacte</a>
+                        <?php
+                                            }
+                                        }
+                                    } else {
+                        ?>
+                        <a id="tar-contacte" target="_blank" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    }
+                                }
+                            }
+                        ?>
                     </div>		 
                 </div>	
             </div>		 

--- a/wp-content/themes/reactor-serveis-educatius/library/inc/customizer/customize.php
+++ b/wp-content/themes/reactor-serveis-educatius/library/inc/customizer/customize.php
@@ -338,18 +338,34 @@ if ( !function_exists('reactor_customize_register') ) {
 					'priority' => 7,
 				 ) );
 
-			$wp_customize->add_setting('reactor_options[emailCentre]', array(
+			// Field to contact page
+			$wp_customize->add_setting('reactor_options[contacteCentre]', array(
 				'default'    => "",
 				'type'       => 'option',
 				'capability' => 'manage_options',
 				'transport'  => 'postMessage',
 			 ) );
-				$wp_customize->add_control('reactor_options[emailCentre]', array(
+				// Field to contact page
+				$wp_customize->add_control('reactor_options[contacteCentre]', array(
 					'label'    => __('Contacte principal', 'reactor'),
 					'section'  => 'reactor_customizer_idcentre',
-                                        'description' => 'Email o pàgina de contacte',
+                    'description' => " <a style='float:left;margin-top:-44px; margin-left:135px;height:0px;width:0px;font-style: normal;' target='_blank' href='http://agora.xtec.cat/moodle/moodle/mod/glossary/view.php?id=1741&mode=entry&hook=2681'> <br> (" . __('Ajuda','reactor') . ")</a>" . __('Pàgina de contacte','reactor'),
 					'priority' => 8,
-				 ) );
+				) );
+
+			// Add field mail
+			$wp_customize->add_setting('reactor_options[correuCentre]', array(
+				'default'    => "",
+				'type'       => 'option',
+				'capability' => 'manage_options',
+				'transport'  => 'postMessage',
+			 ) );
+			$wp_customize->add_control('reactor_options[correuCentre]', array(
+				'label'    => __('Email principal', 'reactor'),
+				'section'  => 'reactor_customizer_idcentre',
+                'description' => __('Adreça electrònica','reactor'),
+				'priority' => 9,
+			 ) );
 
                         global $colors_nodes;
 

--- a/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
@@ -22,7 +22,21 @@ class Logo_Centre_Widget extends WP_Widget {
             echo '<h4 class="widget-title">' . $title . '</h4>';
         }
 
-        $contacte = (strstr(reactor_option('emailCentre'), '@')) ? "mailto:" . reactor_option('emailCentre') : reactor_option('emailCentre');
+        // Check options to print url link or mailto link
+        $contacteCentre = reactor_option('contacteCentre');
+        $correuCentre = reactor_option('correuCentre');
+        $contacte_mobile_enabled = false;
+
+        ( ! empty($contacteCentre) ) ? $contacte = $contacteCentre : $contacte = false;
+        ( ! empty($correuCentre) ) ? $contacte_mobile = "mailto:" . $correuCentre : $contacte_mobile = false;
+
+        if ( $contacte == false && $contacte_mobile != false ){
+            $contacte = $contacte_mobile;
+            $contacte_mobile_enabled = true;
+        } else if ( $contacte_mobile == false && $contacte != false ){
+            $contacte_mobile = $contacte;
+        }
+
         ?>
         <div class="targeta_id_centre row">
             <?php
@@ -63,10 +77,88 @@ class Logo_Centre_Widget extends WP_Widget {
                         <div class="tel">
                             <span><?php echo reactor_option('telCentre'); ?></span>
                         </div>
-                        <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a> 
-                        <span class="pipe" >|</span> 
-                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php
 
+                            // Get home url to check behavior target link
+                            $currentDomain = get_home_url();
+                            $searchDomain = array('http://','https://');
+                            $currentDomain = str_replace($searchDomain,'',$currentDomain);
+                            $contacteDomain = str_replace($searchDomain,'',$contacte);
+
+                            // Check if googleMaps is empty to show or not
+                            $showPipe = false;
+                            $emptyMaps = reactor_option('googleMaps');
+                            if ( ! empty($emptyMaps)){
+                                $showPipe = true;
+                                if ( strpos(reactor_option('googleMaps'),$currentDomain) !== false ){
+                        ?>
+                                    <a id="tar-mapa" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a>
+                        <?php   
+                                } else if ( strpos(reactor_option('googleMaps'),'http') === false ){
+                                    if ( strpos(reactor_option('googleMaps'),'.') !== false ){
+                        ?>
+                                        <a id="tar-mapa" target="_blank" href="<?php echo esc_url("http://" . reactor_option('googleMaps')); ?>">mapa</a>
+                        <?php
+                                    } else {
+                                        if ( substr ( trim(reactor_option('googleMaps')) , 0 , 1 ) == '/' ){
+                        ?>
+                                            <a id="tar-mapa" href=" <?php echo esc_url(get_home_url() . reactor_option('googleMaps')); ?>">mapa</a>
+                        <?php
+                                        } else {
+                        ?>
+                                            <a id="tar-mapa" href=" <?php echo esc_url(get_home_url() . '/' . reactor_option('googleMaps')); ?>">mapa</a>
+                        <?php
+                                        }
+                                    }
+                                } else {
+                        ?>
+                                    <a id="tar-mapa" target="_blank" href="<?php echo reactor_option('googleMaps'); ?>">mapa</a>
+                        <?php
+                                }
+                            } 
+                        ?>
+                        <?php 
+                            // Check if $contacte is empty to show or not
+                            if ( $contacte != false && $contacte_mobile != false ){
+                                if( $showPipe == true ){
+                        ?>
+                                    <span class="pipe" >|</span>
+                        <?php 
+                                } 
+
+                                if ( $contacte_mobile_enabled == true ){
+                        ?>
+                                    <a id="tar-contacte" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php 
+                                } else {
+                                    if ( strpos($contacteDomain,$currentDomain) !== false ){
+                        ?>
+                                        <a id="tar-contacte" href="<?php echo $contacte; ?>">contacte</a>
+                        <?php
+                                    } else if ( strpos($contacte,'http') === false ){
+                                        if ( strpos($contacte,'.') !== false ){
+                        ?>
+                                            <a id="tar-contacte" target="_blank" href="<?php echo esc_url("https://" . $contacte); ?>">contacte</a>
+                        <?php
+                                        } else {
+                                            if ( substr ( trim($contacte) , 0 , 1 ) == '/' ){
+                        ?>
+                                                <a id="tar-contacte" href="<?php echo esc_url($currentDomain . $contacte); ?>">contacte</a>
+                        <?php
+                                            } else {
+                        ?>
+                                                <a id="tar-contacte" href="<?php echo esc_url($currentDomain . '/' . $contacte); ?>">contacte</a>
+                        <?php
+                                            }
+                                        }
+                                    } else {
+                        ?>
+                        <a id="tar-contacte" target="_blank" href="<?php echo esc_url($contacte); ?>">contacte</a>
+                        <?php
+                                    }
+                                }
+                            }
+                        ?>
                     </div>		 
                 </div>	
             </div>		 


### PR DESCRIPTION
Realitzades les modificacions per adaptar el comportament de l'enllaç de "mapa" i "contacte" a les plantilles de reactor-primaria i serveis educatius complint amb els següents requisits:

**Comportament reactor-primaria:**

Versió Escriptori "Contacte":
- Si hi ha pàgina de contacte, crea un enllaç per redirigir.
- Si no hi ha pàgina de contacte, fa un "mailto" a l'adreça de correu.
- Si no hi ha pàgina de contacte, ni adreça de correu, no mostra l'enllaç de contacte.

Versió Escriptori "Mapa":
- Si hi ha contingut, crea un enllaç de redirigir.
- Si no hi ha contingut no mostra l'enllaç.

Versió Mòbil "Contacte":
- Si hi ha adreça de correu, fa un "mailto".
- Si no hi ha adreça de correu, aplica l'enllaç de la pàgina de contacte.
- Si no hi ha adreça de correu ni pàgina de contacte, mostra la icona, sense cap funció (no podem amagar la icona per que no quedaria bé la graella).

Versió Mòbil "Mapa":
- Si hi ha contingut, aplica un enllaç.
- Si no hi ha enllaç de mapa, mostra la icona, sense cap funció (no podem amagar la icona per que no quedaria bé la graella).

**Comportament Serveis educatius:**

Versió Escriptori "Contacte":
- Si hi ha pàgina de contacte, crea un enllaç de redirigir.
- Si no hi ha pàgina de contacte, fa un "mailto" a l'adreça de correu.
- Si no hi ha pàgina de contacte, ni adreça de correu, no mostra l'enllaç de contacte.

Versió Escriptori "Mapa":
- Si hi ha contingut, aplica un ellaç.
- Si no hi ha enllaç no mostra l'enllaç del mapa.

Versió Mòbil:

No aplica.

El comportament del target del enllaç es bassa en les següents regles:

- Si la base és agora.xtec.cat/nompropi:
	- [http[s]://]agora.xtec.cat/nompropi/* s'obrirà a la mateixa finestra.
	- [/] (on no ha de contenir cap ., perquè sinó voldrà dir que és un URL) s'obrirà a la mateixa finestra. Per exemple /activitat o activitat.
	- La resta s'obriran totes en finestra nova. Per exemple:
		[http[s]://]agora.xtec.cat/altrenompropi/*
		[http[s]://]clic.xtec.cat/
		[http[s]://]google.com/

Proves:

- Executar l'operació del portal `script_update_reactor_options`
- Realitzar modificacions sobre el giny Identificació del centre a Mapa, Pàgina de contacte i Correu electrònic
- Revisar el funcionament en la versió escriptori i versió mòbil de les diferents plantilles.