### PR TITLE
Add id attribute to image logo centre

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,7 @@ Changes in progress
 - buddypress-like: Upgraded plugin from 0.2 to 0.3 and converted into a submodule (Trello #1452)
 - buddypress-docs: Upgraded plugin from 1.9.0 to 1.9.2 (Trello #1442)
 - Themes reactor-primaria-1 and reactor-serveis-educatius: Added field email to Fitxa del Centre and modified behaviour of links for contact and map (Trello #1459)
+- Themes reactor-primaria-1 and reactor-serveis-educatius: Added id attribute to site logo (Trello #1477)
 
 
 Changes 16.10.24

--- a/wp-content/themes/reactor-serveis-educatius/library/inc/content/content-header.php
+++ b/wp-content/themes/reactor-serveis-educatius/library/inc/content/content-header.php
@@ -90,7 +90,7 @@ function reactor_do_title_logo()
                 <div class='box-content'>
                     <a href="<?php echo esc_url( home_url( '/' ) ); ?>" >
                         <span style="font-size:<?php echo $description_font_size; ?>">
-                            <img src="<?php echo reactor_option('logo_image'); ?>">
+                            <img id="logo_entity" src="<?php echo reactor_option('logo_image'); ?>">
                         </span>
                     </a>
                 </div>

--- a/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor/custom-tac/ginys/giny-logo-centre.php
@@ -53,7 +53,7 @@ class Logo_Centre_Widget extends WP_Widget {
                 ?>
                 <div class="<?php reactor_columns(array($amplada, 12));
                 echo " " . $class_logo; ?> hide-for-small"> 
-                    <img src="<?php echo reactor_option('logo_image'); ?>">					
+                    <img id="logo_entity" src="<?php echo reactor_option('logo_image'); ?>">					
                 </div> 
             <?php
             } else {


### PR DESCRIPTION
Afegir l'atribut `id="logo_entity"` a la imatge que conté el logo del centre.

Proves:

1. Mitjançant l'inspector de Chrome/Firefox comprovar que l'etiqueta html de la imatge del logo del centre conté l'id.
2. Comprovar a reactor-primaria-1 i reactor-serveis-educatius.