### PR TITLE
Change styles to simple calendar widget

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,7 @@ Changes in progress
 - buddypress-docs: Contributors and Subscribers cannot create documents (Trello #1434)
 - reactor: Deleted duplicated favicon (Trello #1419)
 - reactor: Allow e-mail in header icons. Changed behaviour when a link is clicked (opening in new window or in current window) (Trello #1437)
+- reactor: Changed appearance of widget of Google Calendar Events (Trello #1397)
 - reactor-primaria-1 and reactor-serveis-educatius: Added field email to Fitxa del Centre and modified behaviour of links for contact and map (Trello #1459)
 - reactor-primaria-1 and reactor-serveis-educatius: Added id attribute to site logo (Trello #1477)
 - bbpress: Converted into a submodule (Trello #1454)

--- a/wp-content/themes/reactor/custom-tac/styles/styles.php
+++ b/wp-content/themes/reactor/custom-tac/styles/styles.php
@@ -1,0 +1,19 @@
+<style>
+<?php
+    global $colors_nodes;
+
+    $paleta = reactor_option('paleta_colors','blaus');
+
+    $color_calendar  = isset($colors_nodes[$paleta]["calendar"])?$colors_nodes[$paleta]["calendar"]:$colors_nodes[$paleta]["secondary"];
+?>
+
+    /* ESTILS WIDGET CALENDAR */
+    .widget .simcal-events-dots b{
+        color: <?php echo $color_calendar ?> !important;
+    }
+
+    .widget .simcal-today > div > span.simcal-day-label.simcal-day-number{
+        border: 2px solid <?php echo $color_calendar ?> !important;
+    }
+    /* FI ESTILS WIDGET CALENDAR */
+</style>

--- a/wp-content/themes/reactor/header.php
+++ b/wp-content/themes/reactor/header.php
@@ -13,6 +13,9 @@
 
 <head>
 
+    <!-- Add common styles to all themes -->
+    <?php include get_theme_root()."/reactor/custom-tac/styles/styles.php"; ?>
+
     <?php include get_stylesheet_directory()."/style.php"; ?>
 
     <link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet' type='text/css'>

--- a/wp-content/themes/reactor/style.css
+++ b/wp-content/themes/reactor/style.css
@@ -866,77 +866,6 @@ ul.bbp-topics, .bbp-topic-form {
     clear: inherit !important;
 }
 
-/* Calendari */
-
-.gce-widget-grid .gce-calendar td {
-    background-color: #efefef;
-    border: 0.1em solid white !important;
-    color: #55556a !important;
-}
-
-.gce-widget-grid .gce-calendar td.gce-day-future,
-.gce-widget-grid .gce-calendar td.gce-day-past {
-    color: #55556a !important;
-    font-family: 'Open Sans', sans-serif;
-    font-size: 0.8em;
-    background-color: #e7e7e7;
-    border: 0.1em solid white !important;
-}
-
-.gce-widget-grid .gce-calendar th {
-    border: 0 !important;
-}
-
-.gce-widget-grid .gce-calendar {
-    border: 0 !important;
-}
-
-.gce-widget-grid .gce-calendar .gce-caption {
-    background-color: #e7e7e7;
-    color: #55556a;
-    text-transform: capitalize;
-    padding-top: 0.3em;
-}
-
-.gce-has-events {
-    background-color: #cfcfcf !important;
-    font-weight: bold;
-}
-
-.gce-widget-grid {
-    padding-right: 1em;
-}
-
-.gce-today span.gce-day-number {
-    border-radius: 75%;
-    padding: 5px;
-}
-
-div.gce-widget-grid table tr th,
-div.gce-widget-grid table tr td {
-    padding: 0.5em 0.25em;
-}
-
-.gce-prev .gce-change-month {
-    padding-left: 10px;
-}
-
-div.gce-next .gce-change-month {
-    padding-right: 10px;
-}
-
-.gce-prev .gce-change-month-list:after {
-    content: "Anterior";
-}
-
-div.gce-next .gce-change-month-list:before {
-    content: "Següent";
-}
-
-.gce-widget-list {
-    margin-bottom: 1.5em;
-}
-
 /* Pagination */
 
 ul.pagination {
@@ -1339,3 +1268,85 @@ body.login .wp-social-login-widget {
 div.dir-search {
    margin: 0!important;
 }
+
+/* SIMPLE CALENDAR: ESTILS WIDGET CALENDAR */
+.widget span.simcal-no-events, .simcal-events-dots b{
+        display: none !important;
+}
+
+.widget div.simcal-calendar table.simcal-calendar-grid tr.simcal-week td div span.simcal-events-dots b, .widget .simcal-default-calendar-grid .simcal-events-dots{
+    display: inline !important;
+}
+
+.widget .simcal-day-label.simcal-day-number{
+    background-color: #e7e7e7 !important;
+    color: #59544E !important;
+}
+
+.widget tr.simcal-week{
+    background-color: #e7e7e7;
+}
+
+.widget tr.simcal-week td{
+    border: 1px solid white !important;
+}
+
+.widget .simcal-day-void{
+    background-color: #f5f5f5 !important;
+}
+
+.widget tr.simcal-week div{
+    padding-top: 5px !important;
+    background-color: #e7e7e7;
+
+}
+
+.widget .simcal-current-month, 
+.widget .simcal-current-year{
+    text-transform: capitalize;
+    font-size: 0.7em;
+    color: #59544E !important;
+    font-weight: bold;
+    line-height: 1em;
+    margin-top: -7px !important;
+}
+
+#sidebar-frontpage-2 .widget .simcal-current-month, 
+#sidebar-frontpage-2 .widget .simcal-current-year{
+    font-size: 0.6em !important;
+
+}
+
+.widget .simcal-today > div{
+    border: none !important;
+}
+
+.widget .simcal-today > div > span.simcal-day-label.simcal-day-number{
+    border: none;
+    background-color: transparent !important;
+}
+
+.widget .simcal-default-calendar-grid .simcal-day-number{
+        padding: 0px !important;
+    }
+
+.widget .simcal-default-calendar-grid .simcal-calendar-head .simcal-nav{
+    padding: 5px !important;
+}
+
+#sidebar-frontpage-2 .widget .simcal-default-calendar-grid .simcal-calendar-head .simcal-nav{
+    padding: 2px !important;
+}
+
+#sidebar-frontpage-2 .simcal-calendar-head h3,
+#sidebar-frontpage .simcal-calendar-head h3{
+    margin-top: -7px;
+}
+
+.widget .simcal-today > div > span.simcal-day-label.simcal-day-number{
+    border-radius: 14px !important;
+    margin: 0 auto !important;
+    width: 23px !important;
+    padding: 2px 2px 3px 2px !important;
+}
+/* SIMPLE CALENDAR: FI ESTILS WIDGET CALENDAR */


### PR DESCRIPTION
Esborrar els estils del google-calendar-events i adapatar el widget simple calendar amb els requisits de disseny establerts.

Proves:

1. Cal afegir calendari al simple calendar i afegir el widget.
2. Revisar-ho en el tema reactor-primaria-1 i reactor-serveis-educatius.