### PR TITLE
Hidden some meta-boxes to nav-menus buddypress-docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,7 +14,8 @@ Changes in progress
 - xtec-booking: Fixed some PHP warnings (Trello #1470)
 - xtec-ldap-login: Don't send e-mail when user password is updated
 - agora-functions: Moved Automatic creation of featured image (Imatge resum) from mu-common to agora-functions (Trello #1284)
-- agora-functions: Don't allow change of bbpress role of xtecadmin. Forced to be keymaster. (Trello #1422)
+- agora-functions: Don't allow change of bbpress role of xtecadmin. Forced to be keymaster (Trello #1422)
+- agora-functions and mu-common: Hidden menu metaboxes for buddypress-docs and gce in Appearance | Menus (Trello #1435)
 - mu-common: Allow external requests to gencat.cat from RSS
 - google-analyticator: Upgraded plugin from 6.4.9.7 to 6.5.0.0 (Trello #1372)
 - google-calendar-events: Upgraded plugin from 3.1.2 to 3.1.8 (Trello #1447)

--- a/wp-content/mu-plugins/agora-functions.php
+++ b/wp-content/mu-plugins/agora-functions.php
@@ -1330,7 +1330,6 @@ add_action('new_to_publish', 'automatic_summary_image');
 add_action('pending_to_publish', 'automatic_summary_image');
 add_action('future_to_publish', 'automatic_summary_image');
 
-
 // Buddypress-docs
 
 /**
@@ -1368,9 +1367,6 @@ function xtec_caps_bpdocs($caps, $cap, $user_id, $args){
 }
 add_filter('bp_docs_map_meta_caps','xtec_caps_bpdocs', 10, 4);
 
-
-// Buddypress
-
 /**
  * Don't allow change of bbpress role to xtecadmin. Forced to be keymaster.
  *
@@ -1390,3 +1386,17 @@ function xtec_filter_bbp_set_user_role( $new_role, $user_id, $user ) {
     return $new_role;
 }
 add_filter( 'bbp_set_user_role', 'xtec_filter_bbp_set_user_role', 10, 3 );
+
+/**
+ * Hidden some metaboxes in nav-menus for buddypress-docs
+ *
+ * @author Xavier Nieto
+ */
+function remove_nav_menu_metaboxes_nodes( $metaboxes ) {
+    if ( !is_xtec_super_admin() ) {
+        remove_meta_box( 'add-bp_docs_folder_in_user', 'nav-menus', 'side' );
+        remove_meta_box( 'add-bp_docs_folder_in_group', 'nav-menus', 'side' );
+        remove_meta_box( 'add-bp_docs_access', 'nav-menus', 'side' );
+    }
+}
+add_action( 'admin_head-nav-menus.php', 'remove_nav_menu_metaboxes_nodes', 10, 1 );


### PR DESCRIPTION
Eliminar el meta_box per tal de no poder escollir diferents etiquetes de buddypress-docs com a menú.

Proves: 

1. Provar amb un usuari diferent al xtec_admin, i anar a Aparença | Menú i veure que només hi ha un checkbox amb el nom Etiquetes.
2. Provar amb usuari xtec_admin, i anar a Aparença | Menú i veure que hi han 4 checkbox amb el nom Etiquetes.