### PR TITLE
Fix the border right when mouse over at dot

### DIFF
--- a/wp-content/plugins/xtec-booking/css/xtec-booking.css
+++ b/wp-content/plugins/xtec-booking/css/xtec-booking.css
@@ -290,6 +290,10 @@ span.weekdays{
 	background-color:  #dbf8ff !important;
 }
 
+.cal-cell1.cal-cell.day-highlight{
+	border-color: #E1E1E1 !important;
+}
+
 /* REPLACE COLOR ORIGINAL */
 .dh-event-special{
 	background-color:  #ecd9f8 !important;


### PR DESCRIPTION
Corregir la vora dreta al situar-se amb el ratolí sobre la rodona de la reserva a la vista de calendari mes.

Proves:

- Revisar que al passar per sobre de la rodona de la reserva, a la vista de calendari/mes, la vora dreta surt bé.