### PR TITLE
Fix php notice reactor-serveis-educatius

### DIFF
--- a/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
+++ b/wp-content/themes/reactor-serveis-educatius/custom-tac/ginys/giny-logo-centre.php
@@ -39,7 +39,13 @@ class Logo_Centre_Widget extends WP_Widget {
 
         ?>
         <div class="targeta_id_centre row">
-            <?php list($postal_code, $locality) = explode(" ", reactor_option("cpCentre"), 1); ?>
+            <?php
+                $xtec_cpCentre = explode(" ", reactor_option("cpCentre"), 1);
+                $postal_code = '';
+                $locality = '';
+                if( isset($xtec_cpCentre[0]) ){ $postal_code = $xtec_cpCentre[0]; }
+                if( isset($xtec_cpCentre[1]) ){ $locality = $xtec_cpCentre[1]; }
+            ?>
             <?php
             $amplada = "12";
             $class = "no_logo";


### PR DESCRIPTION
Correcció d'una alerta de Php.

Proves:

Per tal de provar-ho cal anar a un centre amb el tema reactor-serveis-educatius i anar al peu de la pàgina.
Observar que les dades del centre de la part dreta es visualitza correctament i amb `debug` activat no apareix cap notificació.