### PR TITLE
Add condition to cannot select other theme into AGORA-EOI

### DIFF
--- a/wp-includes/theme.php
+++ b/wp-includes/theme.php
@@ -73,17 +73,19 @@ function wp_get_themes( $args = array() ) {
 		$CheckServei = isServeiEducatiu();
 		$CheckProject = isProjecte();
 
-        if( is_agora() && 
+		if( is_agora() && 
             (( $CheckServei === true && strcmp( 'reactor-primaria-1', $theme ) === 0 ) ||
              ( $CheckServei === true && strcmp( 'reactor-projectes', $theme ) === 0 ) ||
              ( $CheckServei === false && strcmp( 'reactor-serveis-educatius', $theme ) === 0 ) ||
              ( $CheckServei === false  && strcmp( 'reactor-projectes', $theme ) === 0 ) ||
+             ( $CheckServei === false  && strcmp( 'reactor-primaria-1', $theme ) === 0 ) ||
              ( $CheckProject === true && strcmp( 'reactor-primaria-1', $theme ) === 0 ) ||
              ( $CheckProject === true && strcmp( 'reactor-serveis-educatius', $theme ) === 0 ) ||
              ( $theme == 'reactor' ) )
         ) {
             continue;
         }
+
 //************ FI
 
 		if ( isset( $_themes[ $theme_root['theme_root'] . '/' . $theme ] ) )


### PR DESCRIPTION
Afegir condició per evitar la selecció de themes en els AGORA-EOI

Proves:

- Cal anar a Aparença | temes a sites NODES primari, serveis educatius, EOI i projectes, i comprovar que no es pot seleccionar cap altre theme.