### PR TITLE
Cron to remove old bookings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ development home at https://github.com/projectestac/agora_nodes
 Changes in progress
 ---------------------------------------------------------------------------------------
 - buddypress-group-email-subscription: Upgraded plugin from version 3.6.1 to 3.7.0
+- xtec-booking: Added cron to remove old bookings
 
 
 Changes 17.05.23

--- a/wp-content/plugins/xtec-booking/includes/cron.php
+++ b/wp-content/plugins/xtec-booking/includes/cron.php
@@ -1,0 +1,36 @@
+<?php
+
+function check_old_bookings() {
+
+	$args = array(
+		'post_type'   			=> 'calendar_booking',
+		'post_status' 			=> 'publish',
+		'posts_per_page' 		=> -1,
+  		'ignore_sticky_posts'	=> 1
+	);
+
+	$posts = get_posts( $args );
+
+	foreach ( $posts as $post ) {
+
+		$postmeta = get_post_meta( $post->ID );
+		$data = unserialize( $postmeta['_xtec-booking-data'][0] );
+
+		$timeStart = explode( ':',$data['_xtec-booking-start-time'] );
+		$timeEnd = explode( ':',$data['_xtec-booking-finish-time'] );
+		$dateStart = explode( '-',$data['_xtec-booking-start-date'] );
+		$dateEnd = explode( '-',$data['_xtec-booking-finish-date'] );
+
+		$StartDateTimePastYear = mktime( $timeStart[0],$timeStart[1],0,($dateStart[1]+1),$dateStart[0],($dateStart[2]+1) );
+		$EndDateTimePastYear = mktime( $timeEnd[0],$timeEnd[1],0,$dateEnd[1],$dateEnd[0],($dateEnd[2]+1) );
+
+		if( time() > $EndDateTimePastYear ){
+			delete_post_meta( $post->ID, '_xtec-booking-data' );
+			wp_delete_post( $post->ID );
+		} else if( time() > $StartDateTimePastYear ){
+			$StartDateTimePastYear = mktime( $timeStart[0],$timeStart[1],0,$dateStart[1],$dateStart[0],($dateStart[2]+1) );
+			$data['_xtec-booking-start-date'] = date('d-m-Y',$StartDateTimePastYear);
+			update_post_meta( $post->ID, '_xtec-booking-data', $data );
+		}
+	}
+}

--- a/wp-content/plugins/xtec-booking/xtec-booking.php
+++ b/wp-content/plugins/xtec-booking/xtec-booking.php
@@ -13,6 +13,7 @@ include( plugin_dir_path( __FILE__ ) . 'includes/resources.php' );
 include( plugin_dir_path( __FILE__ ) . 'includes/booking.php' );
 include( plugin_dir_path( __FILE__ ) . 'includes/calendar.php' );
 include( plugin_dir_path( __FILE__ ) . 'includes/actions_calendar.php' );
+include( plugin_dir_path( __FILE__ ) . 'includes/cron.php' );
 
 // LOAD LANGUAGE FILE
 function xtec_booking_load_language_file(){
@@ -606,3 +607,6 @@ function xtec_booking_calendar_title($title){
 	return $title;
 }
 add_action('admin_title','xtec_booking_calendar_title');
+
+// CRON TO REMOVE OLD BOOKINGS
+add_action( 'cron_xtec_booking', 'check_old_bookings' );


### PR DESCRIPTION
Afegida la lógica del cron que eliminar les reserves antigues.

Proves:

- Cal programar reserves antigues, on la data final faci més d'un any que ha passat, o reserves que encara estiguin vigents i que la data d'inici faci més d'un any d'antiguitat.
- Després cal executar la operació del portal i el wp-cron.php